### PR TITLE
gui[g-all]: Implemented MaterialDesign, redesigned buttons, colours and styles

### DIFF
--- a/HealthcareSystem/DoctorFrontend/App.xaml
+++ b/HealthcareSystem/DoctorFrontend/App.xaml
@@ -4,6 +4,23 @@
              xmlns:local="clr-namespace:WpfApp1"
              StartupUri="Wizard/Window1.xaml">
     <Application.Resources>
-         
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Light.xaml" />
+                <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Defaults.xaml" />
+                <ResourceDictionary Source="pack://application:,,,/MaterialDesignColors;component/Themes/Recommended/Primary/MaterialDesignColor.DeepPurple.xaml" />
+                <ResourceDictionary Source="pack://application:,,,/MaterialDesignColors;component/Themes/Recommended/Accent/MaterialDesignColor.Lime.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+
+
+            <Style TargetType="Button">
+                <Setter Property="Padding" Value="0"/>
+            </Style>
+
+            <Style TargetType="MenuItem">
+                <Setter Property="Padding" Value="10 2 10 0"/>
+            </Style>
+            
+        </ResourceDictionary>
     </Application.Resources>
 </Application>

--- a/HealthcareSystem/DoctorFrontend/DoctorFrontend.csproj
+++ b/HealthcareSystem/DoctorFrontend/DoctorFrontend.csproj
@@ -14,6 +14,8 @@
     <WarningLevel>4</WarningLevel>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Deterministic>true</Deterministic>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -35,6 +37,12 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="MaterialDesignColors, Version=1.2.7.1979, Culture=neutral, PublicKeyToken=df2a72020bd7962a, processorArchitecture=MSIL">
+      <HintPath>..\packages\MaterialDesignColors.1.2.7\lib\net45\MaterialDesignColors.dll</HintPath>
+    </Reference>
+    <Reference Include="MaterialDesignThemes.Wpf, Version=3.2.0.1979, Culture=neutral, PublicKeyToken=df2a72020bd7962a, processorArchitecture=MSIL">
+      <HintPath>..\packages\MaterialDesignThemes.3.2.0\lib\net45\MaterialDesignThemes.Wpf.dll</HintPath>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
@@ -420,4 +428,11 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\packages\MaterialDesignThemes.3.2.0\build\MaterialDesignThemes.targets" Condition="Exists('..\packages\MaterialDesignThemes.3.2.0\build\MaterialDesignThemes.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\MaterialDesignThemes.3.2.0\build\MaterialDesignThemes.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MaterialDesignThemes.3.2.0\build\MaterialDesignThemes.targets'))" />
+  </Target>
 </Project>

--- a/HealthcareSystem/DoctorFrontend/MainWindow.xaml
+++ b/HealthcareSystem/DoctorFrontend/MainWindow.xaml
@@ -1,5 +1,6 @@
 ﻿<Window x:Class="WpfApp1.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"

--- a/HealthcareSystem/DoctorFrontend/packages.config
+++ b/HealthcareSystem/DoctorFrontend/packages.config
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="MaterialDesignColors" version="1.2.7" targetFramework="net472" />
+  <package id="MaterialDesignThemes" version="3.2.0" targetFramework="net472" />
   <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net472" />
   <package id="Syncfusion.Compression.Base" version="18.1.0.55" targetFramework="net472" />
   <package id="Syncfusion.Licensing" version="18.1.0.55" targetFramework="net472" />

--- a/HealthcareSystem/GraphicalEditor/App.xaml
+++ b/HealthcareSystem/GraphicalEditor/App.xaml
@@ -4,6 +4,13 @@
              xmlns:local="clr-namespace:GraphicalEditor"
              StartupUri="MainWindow.xaml">
     <Application.Resources>
-         
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Light.xaml" />
+                <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Defaults.xaml" />
+                <ResourceDictionary Source="pack://application:,,,/MaterialDesignColors;component/Themes/Recommended/Primary/MaterialDesignColor.DeepPurple.xaml" />
+                <ResourceDictionary Source="pack://application:,,,/MaterialDesignColors;component/Themes/Recommended/Accent/MaterialDesignColor.Lime.xaml" />
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
     </Application.Resources>
 </Application>

--- a/HealthcareSystem/GraphicalEditor/GraphicalEditor.csproj
+++ b/HealthcareSystem/GraphicalEditor/GraphicalEditor.csproj
@@ -14,6 +14,8 @@
     <WarningLevel>4</WarningLevel>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Deterministic>true</Deterministic>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -35,6 +37,12 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="MaterialDesignColors, Version=1.2.7.1979, Culture=neutral, PublicKeyToken=df2a72020bd7962a, processorArchitecture=MSIL">
+      <HintPath>..\packages\MaterialDesignColors.1.2.7\lib\net45\MaterialDesignColors.dll</HintPath>
+    </Reference>
+    <Reference Include="MaterialDesignThemes.Wpf, Version=3.2.0.1979, Culture=neutral, PublicKeyToken=df2a72020bd7962a, processorArchitecture=MSIL">
+      <HintPath>..\packages\MaterialDesignThemes.3.2.0\lib\net45\MaterialDesignThemes.Wpf.dll</HintPath>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
@@ -122,4 +130,11 @@
   </ItemGroup>
   <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\packages\MaterialDesignThemes.3.2.0\build\MaterialDesignThemes.targets" Condition="Exists('..\packages\MaterialDesignThemes.3.2.0\build\MaterialDesignThemes.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\MaterialDesignThemes.3.2.0\build\MaterialDesignThemes.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MaterialDesignThemes.3.2.0\build\MaterialDesignThemes.targets'))" />
+  </Target>
 </Project>

--- a/HealthcareSystem/GraphicalEditor/MainWindow.xaml
+++ b/HealthcareSystem/GraphicalEditor/MainWindow.xaml
@@ -1,12 +1,20 @@
 ﻿<Window x:Class="GraphicalEditor.MainWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:GraphicalEditor"
         mc:Ignorable="d"
         WindowState="Maximized"
-        Title="MainWindow" Height="800" Width="1500">
+        TextElement.Foreground="{DynamicResource MaterialDesignBody}"
+        TextElement.FontWeight="Regular"
+        TextElement.FontSize="13"
+        TextOptions.TextFormattingMode="Ideal"
+        TextOptions.TextRenderingMode="Auto"
+        Background="{DynamicResource MaterialDesignPaper}"
+        FontFamily="{DynamicResource MaterialDesignFont}"
+        Title="Grafički editor sa mapom bolnice" Height="800" Width="1500" WindowStartupLocation="CenterScreen">
     <DockPanel>
         <StackPanel DockPanel.Dock="Left" Margin="20 20 0 0" >
             <Canvas x:Name="Canvas" Height="700" Width="1086" 
@@ -182,67 +190,75 @@
         <Border DockPanel.Dock="Right"
                 Margin="0 20 0 50"
                 Padding="10 0 10 0">
-                <StackPanel x:Name="InformationDisplay">
+            <StackPanel x:Name="InformationDisplay">
 
-                    <StackPanel.Resources>
+                <StackPanel.Resources>
 
-                        <Style x:Key="NormalMode" TargetType="StackPanel">
-                            <Style.Triggers>
-                                <DataTrigger Binding="{Binding EditMode}" Value="False">
-                                    <Setter Property="Visibility" Value="Visible" />
-                                </DataTrigger>
-                                <DataTrigger Binding="{Binding EditMode}" Value="True">
-                                    <Setter Property="Visibility" Value="Collapsed" />
-                                </DataTrigger>
-                            </Style.Triggers>
-                        </Style>
+                    <Style x:Key="NormalMode" TargetType="StackPanel">
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding EditMode}" Value="False">
+                                <Setter Property="Visibility" Value="Visible" />
+                            </DataTrigger>
+                            <DataTrigger Binding="{Binding EditMode}" Value="True">
+                                <Setter Property="Visibility" Value="Collapsed" />
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
 
-                        <Style x:Key="EditingMode" TargetType="StackPanel">
-                            <Style.Triggers>
-                                <DataTrigger Binding="{Binding EditMode}" Value="False">
-                                    <Setter Property="Visibility" Value="Collapsed" />
-                                </DataTrigger>
-                                <DataTrigger Binding="{Binding EditMode}" Value="True">
-                                    <Setter Property="Visibility" Value="Visible" />
-                                </DataTrigger>
-                            </Style.Triggers>
-                        </Style>
+                    <Style x:Key="EditingMode" TargetType="StackPanel">
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding EditMode}" Value="False">
+                                <Setter Property="Visibility" Value="Collapsed" />
+                            </DataTrigger>
+                            <DataTrigger Binding="{Binding EditMode}" Value="True">
+                                <Setter Property="Visibility" Value="Visible" />
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
 
-                    </StackPanel.Resources>
-    
-                    <StackPanel x:Name="NormalPanel" 
+                </StackPanel.Resources>
+
+                <StackPanel x:Name="NormalPanel" 
                             Style="{StaticResource NormalMode}">
-                        <TextBlock Text="{Binding DisplayMapObject.MapObjectType.ObjectTypeFullName}" 
+                    <TextBlock Text="{Binding DisplayMapObject.MapObjectType.ObjectTypeFullName}" 
                            FontSize="26" 
                            TextWrapping="Wrap"
                            HorizontalAlignment="Center">
-                        </TextBlock>
+                    </TextBlock>
 
-                        <TextBlock Text="{Binding DisplayMapObject.Id}" 
+                    <TextBlock Text="{Binding DisplayMapObject.Id}" 
                             FontSize="20"
                             Margin="0 5 0 0"
                             HorizontalAlignment="Center"/>
 
-                        <TextBlock x:Name="Prop" Text="{Binding DisplayMapObject.Description}" 
+                    <TextBlock x:Name="Prop" Text="{Binding DisplayMapObject.Description}" 
                            TextWrapping="Wrap"
                            FontSize="16" 
                            Margin="0 10 0 0">
-                        </TextBlock>
+                    </TextBlock>
 
-                        <Button x:Name="EditObjectButton" Content="Izmeni"
-                            Padding="10"
+                    <Button
+                            x:Name="EditObjectButton"
+                            Height="Auto"
+                            Padding="5"
                             FontSize="18"
                             Margin="0 10"
+                            Background="#7D80DA"
+                            BorderBrush="{x:Null}"
                             Click="Edit_Display_Information">
-                        </Button>
+                        <StackPanel Orientation="Horizontal" VerticalAlignment="Center" HorizontalAlignment="Center">
+                            <materialDesign:PackIcon Kind="Edit" Foreground="White" Width="25" Height="25"  HorizontalAlignment="Left" VerticalAlignment="Center"/>
+                            <TextBlock Text="Izmeni" Foreground="White" HorizontalAlignment="Right" VerticalAlignment="Center" Margin="5"/>
+                        </StackPanel>
+                    </Button>
 
-                        
-                    </StackPanel>
+                </StackPanel>
 
-                    <StackPanel x:Name="EditPanel"
+                <StackPanel x:Name="EditPanel"
                             Style="{StaticResource EditingMode}">
                     <ComboBox Name="ObjectTypeChooserComboBox" ItemsSource="{Binding DisplayMapObject.MapObjectType.AllMapObjectTypesAvailableToChange}"
-                             >
+                              FontSize="16"
+                              materialDesign:HintAssist.Hint="Izaberite tip objekta.">
                         <ComboBox.ItemTemplate>
                             <DataTemplate>
                                 <TextBlock Text="{Binding Path=ObjectTypeFullName}"></TextBlock>
@@ -255,29 +271,44 @@
                            Margin="0 5 0 0"
                            HorizontalAlignment="Center"/>
 
-                        <TextBox Text="{Binding DisplayMapObject.Description}" 
+                    <TextBox Text="{Binding DisplayMapObject.Description}" 
                            TextWrapping="Wrap"
                            FontSize="16" 
-                           Margin="0 10 0 0">
-                        </TextBox>
+                           Margin="0 10 0 0"
+                           materialDesign:HintAssist.Hint="Unesite deskripciju objekta.">
+                    </TextBox>
 
-                        <Button x:Name="SaveButton" Content="Sačuvaj"
-                            Padding="10"
+                    <Button 
+                            x:Name="SaveButton"
+                            Height="Auto"
+                            Padding="5"
                             FontSize="18"
-                            Margin="0 10"
+                            Margin="0 15 0 0"
+                            Background="#7D80DA"
+                            BorderBrush="{x:Null}"
                             Click="Change_Display_Information">
-                        </Button>
+                        <StackPanel Orientation="Horizontal" VerticalAlignment="Center" HorizontalAlignment="Center">
+                            <materialDesign:PackIcon Kind="ContentSave" Foreground="White" Width="25" Height="25"  HorizontalAlignment="Left" VerticalAlignment="Center"/>
+                            <TextBlock Text="Sačuvaj" Foreground="White" HorizontalAlignment="Right" VerticalAlignment="Center" Margin="5"/>
+                        </StackPanel>
+                    </Button>
 
-                        <Button Content="Otkaži"
-                            Padding="10"
+                    <Button 
+                            Height="Auto"
+                            Padding="5"
                             FontSize="18"
-                            Margin="0 5"
+                            Margin="0 10 0 0"
+                            Background="#F2404C"
+                            BorderBrush="{x:Null}"
                             Click="Cancel_Editing_Mode">
-                        </Button>
-
-                    </StackPanel>
+                        <StackPanel Orientation="Horizontal" VerticalAlignment="Center" HorizontalAlignment="Center">
+                            <materialDesign:PackIcon Kind="CloseBox" Foreground="White" Width="25" Height="25"  HorizontalAlignment="Left" VerticalAlignment="Center"/>
+                            <TextBlock Text="Otkaži   " Foreground="White" HorizontalAlignment="Right" VerticalAlignment="Center" Margin="5"/>
+                        </StackPanel>
+                    </Button>
 
                 </StackPanel>
-            </Border>
+            </StackPanel>
+        </Border>
     </DockPanel>
 </Window>

--- a/HealthcareSystem/GraphicalEditor/Models/MapObjectRelated/BuildingLayersButtons.cs
+++ b/HealthcareSystem/GraphicalEditor/Models/MapObjectRelated/BuildingLayersButtons.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Media;
 
@@ -35,7 +36,10 @@ namespace GraphicalEditor.Models.MapObjectRelated
                 LayersSelectButtons[i].Content = i;
                 LayersSelectButtons[i].Width = AllConstants.LAYERS_BUTTON_WIDTH;
                 LayersSelectButtons[i].Height = AllConstants.LAYERS_BUTTON_HEIGHT;
-                LayersSelectButtons[i].Background = new SolidColorBrush(Colors.Plum);
+                LayersSelectButtons[i].Padding = new Thickness(0, 0, 0, 0);
+                LayersSelectButtons[i].FontSize = 18;
+                LayersSelectButtons[i].Foreground = new SolidColorBrush(Colors.White);
+                LayersSelectButtons[i].Background = new SolidColorBrush(Colors.MediumPurple);
                 LayersSelectButtons[i].SetValue(Canvas.LeftProperty, CalculateLayersButtonsX(i, numberOfFloors));
                 LayersSelectButtons[i].SetValue(Canvas.TopProperty, CalculateLayersButtonsY(i, numberOfFloors));
             }

--- a/HealthcareSystem/GraphicalEditor/packages.config
+++ b/HealthcareSystem/GraphicalEditor/packages.config
@@ -1,4 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="MaterialDesignColors" version="1.2.7" targetFramework="net472" />
+  <package id="MaterialDesignThemes" version="3.2.0" targetFramework="net472" />
   <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net472" />
 </packages>

--- a/HealthcareSystem/ManagerFrontend/ManagerFrontend.csproj
+++ b/HealthcareSystem/ManagerFrontend/ManagerFrontend.csproj
@@ -37,11 +37,11 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="MaterialDesignColors, Version=1.2.6.1513, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\MaterialDesignColors.1.2.6\lib\net45\MaterialDesignColors.dll</HintPath>
+    <Reference Include="MaterialDesignColors, Version=1.2.7.1979, Culture=neutral, PublicKeyToken=df2a72020bd7962a, processorArchitecture=MSIL">
+      <HintPath>..\packages\MaterialDesignColors.1.2.7\lib\net45\MaterialDesignColors.dll</HintPath>
     </Reference>
-    <Reference Include="MaterialDesignThemes.Wpf, Version=3.1.3.1513, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\MaterialDesignThemes.3.1.3\lib\net45\MaterialDesignThemes.Wpf.dll</HintPath>
+    <Reference Include="MaterialDesignThemes.Wpf, Version=3.2.0.1979, Culture=neutral, PublicKeyToken=df2a72020bd7962a, processorArchitecture=MSIL">
+      <HintPath>..\packages\MaterialDesignThemes.3.2.0\lib\net45\MaterialDesignThemes.Wpf.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
@@ -236,11 +236,11 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\MaterialDesignThemes.3.1.3\build\MaterialDesignThemes.targets" Condition="Exists('..\packages\MaterialDesignThemes.3.1.3\build\MaterialDesignThemes.targets')" />
+  <Import Project="..\packages\MaterialDesignThemes.3.2.0\build\MaterialDesignThemes.targets" Condition="Exists('..\packages\MaterialDesignThemes.3.2.0\build\MaterialDesignThemes.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\MaterialDesignThemes.3.1.3\build\MaterialDesignThemes.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MaterialDesignThemes.3.1.3\build\MaterialDesignThemes.targets'))" />
+    <Error Condition="!Exists('..\packages\MaterialDesignThemes.3.2.0\build\MaterialDesignThemes.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MaterialDesignThemes.3.2.0\build\MaterialDesignThemes.targets'))" />
   </Target>
 </Project>

--- a/HealthcareSystem/ManagerFrontend/packages.config
+++ b/HealthcareSystem/ManagerFrontend/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MaterialDesignColors" version="1.2.6" targetFramework="net472" />
-  <package id="MaterialDesignThemes" version="3.1.3" targetFramework="net472" />
+  <package id="MaterialDesignColors" version="1.2.7" targetFramework="net472" />
+  <package id="MaterialDesignThemes" version="3.2.0" targetFramework="net472" />
   <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net472" />
   <package id="System.Collections.NonGeneric" version="4.3.0" targetFramework="net472" />
 </packages>

--- a/HealthcareSystem/SecretaryFrontend/SecretaryFrontend.csproj
+++ b/HealthcareSystem/SecretaryFrontend/SecretaryFrontend.csproj
@@ -37,11 +37,11 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="MaterialDesignColors, Version=1.2.4.1361, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\MaterialDesignColors.1.2.4\lib\net45\MaterialDesignColors.dll</HintPath>
+    <Reference Include="MaterialDesignColors, Version=1.2.7.1979, Culture=neutral, PublicKeyToken=df2a72020bd7962a, processorArchitecture=MSIL">
+      <HintPath>..\packages\MaterialDesignColors.1.2.7\lib\net45\MaterialDesignColors.dll</HintPath>
     </Reference>
-    <Reference Include="MaterialDesignThemes.Wpf, Version=3.1.1.1361, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\MaterialDesignThemes.3.1.1\lib\net45\MaterialDesignThemes.Wpf.dll</HintPath>
+    <Reference Include="MaterialDesignThemes.Wpf, Version=3.2.0.1979, Culture=neutral, PublicKeyToken=df2a72020bd7962a, processorArchitecture=MSIL">
+      <HintPath>..\packages\MaterialDesignThemes.3.2.0\lib\net45\MaterialDesignThemes.Wpf.dll</HintPath>
     </Reference>
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
@@ -379,11 +379,11 @@
     <Resource Include="Resources\Icons\map.png" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\MaterialDesignThemes.3.1.1\build\MaterialDesignThemes.targets" Condition="Exists('..\packages\MaterialDesignThemes.3.1.1\build\MaterialDesignThemes.targets')" />
+  <Import Project="..\packages\MaterialDesignThemes.3.2.0\build\MaterialDesignThemes.targets" Condition="Exists('..\packages\MaterialDesignThemes.3.2.0\build\MaterialDesignThemes.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\MaterialDesignThemes.3.1.1\build\MaterialDesignThemes.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MaterialDesignThemes.3.1.1\build\MaterialDesignThemes.targets'))" />
+    <Error Condition="!Exists('..\packages\MaterialDesignThemes.3.2.0\build\MaterialDesignThemes.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MaterialDesignThemes.3.2.0\build\MaterialDesignThemes.targets'))" />
   </Target>
 </Project>

--- a/HealthcareSystem/SecretaryFrontend/packages.config
+++ b/HealthcareSystem/SecretaryFrontend/packages.config
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MaterialDesignColors" version="1.2.4" targetFramework="net472" />
-  <package id="MaterialDesignThemes" version="3.1.1" targetFramework="net472" />
+  <package id="MaterialDesignColors" version="1.2.7" targetFramework="net472" />
+  <package id="MaterialDesignThemes" version="3.2.0" targetFramework="net472" />
   <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net472" />
   <package id="OxyPlot.Core" version="2.0.0" targetFramework="net472" />
   <package id="OxyPlot.Wpf" version="2.0.0" targetFramework="net472" />


### PR DESCRIPTION
-On this branch I have implemented MaterialDesign in GraphicalEditor project, DoctorWPF (it was necessary because it calls GraphicalEditor project) and updated MaterialDesign version in Manager and Secretary WPFs (this was necessary too, because versions in GraphicalEditor and other WPFs need to match because these WPFs call GraphicalEditor). 
-I have updated colours, button design and style of some controls

This is only XAML code so there is not much to review...