### PR TITLE
fix[g4]: Loading mockup objects - Fixed error in loops for drawing objects

### DIFF
--- a/HealthcareSystem/GraphicalEditor/Models/MapObjectRelated/MockupObjects.cs
+++ b/HealthcareSystem/GraphicalEditor/Models/MapObjectRelated/MockupObjects.cs
@@ -330,18 +330,18 @@ namespace GraphicalEditor.Models.MapObjectRelated
                 {
                     yOfObject += 80 + i * Constants.AllConstants.RECTANGLE_STROKE_THICKNESS;
                 }
+                else
+                {
+                    MapObject examiantionRoomInBuilding2GroundLevel = new MapObject(
+                        new Room(
+                            TypeOfMapObject.EXAMINATION_ROOM, DepartmentOfMapObject.PULMOLOGY, SecondBuilding, 0, "Examination room " + i
+                        ),
+                        new MapObjectMetrics(startXOfDrawing, yOfObject, widthOfObject, heightOfObject),
+                        new MapObjectDoor(MapObjectDoorOrientation.RIGHT, 0, 0)
+                    );
 
-
-                MapObject examiantionRoomInBuilding2GroundLevel = new MapObject(
-               new Room(
-                   TypeOfMapObject.EXAMINATION_ROOM, DepartmentOfMapObject.PULMOLOGY, SecondBuilding, 0, "Examination room " + i
-               ),
-               new MapObjectMetrics(startXOfDrawing, yOfObject, widthOfObject, heightOfObject),
-               new MapObjectDoor(MapObjectDoorOrientation.RIGHT, 0, 0)
-            );
-
-                AllMapObjects.Add(examiantionRoomInBuilding2GroundLevel);
-
+                    AllMapObjects.Add(examiantionRoomInBuilding2GroundLevel);
+                }
             }
 
             for (int i = 0; i <= 6; i++)
@@ -360,18 +360,18 @@ namespace GraphicalEditor.Models.MapObjectRelated
                 {
                     yOfObject += 80 + i * Constants.AllConstants.RECTANGLE_STROKE_THICKNESS;
                 }
+                else
+                {
+                    MapObject operationRoomInBuilding2GroundLevel = new MapObject(
+                        new Room(
+                            TypeOfMapObject.OPERATION_ROOM, DepartmentOfMapObject.PULMOLOGY, SecondBuilding, 0, "Operation Room " + i
+                        ),
+                        new MapObjectMetrics(startXOfDrawing, yOfObject, widthOfObject, heightOfObject),
+                        new MapObjectDoor(MapObjectDoorOrientation.LEFT, 0, 0)
+                    );
 
-
-                MapObject operationRoomInBuilding2GroundLevel = new MapObject(
-               new Room(
-                   TypeOfMapObject.OPERATION_ROOM, DepartmentOfMapObject.PULMOLOGY, SecondBuilding, 0, "Operation Room " + i
-               ),
-               new MapObjectMetrics(startXOfDrawing, yOfObject, widthOfObject, heightOfObject),
-               new MapObjectDoor(MapObjectDoorOrientation.LEFT, 0, 0)
-            );
-
-                AllMapObjects.Add(operationRoomInBuilding2GroundLevel);
-
+                    AllMapObjects.Add(operationRoomInBuilding2GroundLevel);
+                }
             }
         }
 


### PR DESCRIPTION
- This branch contains code for drawing all map objects.
- We used MockupObjects class to load initial objects to file, but there was bug in for loop for drawing column of rooms, which caused two rooms two load twice instead of once. Because of this, json file from which we load map objects also had this problem. 
- This bug caused another bug for Selection Effect on mouse click on those two objects, so this fix solved that bug, too.