### PR TITLE
feature[g1]: Access map through Patient WPF

### DIFF
--- a/HealthcareSystem/DoctorFrontend/HomePage.xaml
+++ b/HealthcareSystem/DoctorFrontend/HomePage.xaml
@@ -56,9 +56,9 @@
                     Informacije o nalogu i odjava
                 </MenuItem.ToolTip>
             </MenuItem>
-            <MenuItem Header="Mapa" Click="Navigation_Graphical_Editor_Click">
+            <MenuItem Header="Mapa bolnice" Click="Navigation_Graphical_Editor_Click">
                 <MenuItem.ToolTip>
-                    Mapa bolnice
+                    Grafički editor sa mapom bolnice
                 </MenuItem.ToolTip>
             </MenuItem>
         </Menu>

--- a/HealthcareSystem/PatientFrontend/App.xaml
+++ b/HealthcareSystem/PatientFrontend/App.xaml
@@ -4,235 +4,245 @@
              xmlns:local="clr-namespace:ZdravoKorporacija"
              StartupUri="View/MainWindow.xaml">
     <Application.Resources>
-        <Style TargetType="local:MainWindow">
-            <Setter Property="FontSize" Value="20"/>
-            <Setter Property="ResizeMode" Value="NoResize"/>
-        </Style>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Light.xaml" />
+                <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Defaults.xaml" />
+                <ResourceDictionary Source="pack://application:,,,/MaterialDesignColors;component/Themes/Recommended/Primary/MaterialDesignColor.DeepPurple.xaml" />
+                <ResourceDictionary Source="pack://application:,,,/MaterialDesignColors;component/Themes/Recommended/Accent/MaterialDesignColor.Lime.xaml" />
+            </ResourceDictionary.MergedDictionaries>
 
-        <Style TargetType="local:RegistrationWindow">
-            <Setter Property="FontSize" Value="20"/>
-            <Setter Property="ResizeMode" Value="NoResize"/>
-        </Style>
 
-        <Style TargetType="Label">
-            <Setter Property="FontSize" Value="20"/>
-            <Setter Property="Foreground" Value="DarkBlue"/>
-            <Setter Property="HorizontalContentAlignment" Value="Right"/>
-            <Setter Property="Width" Value="350"/>
-            <Setter Property="Margin" Value="5"/>
-            <Setter Property="Grid.ColumnSpan" Value="2"/>
-        </Style>
+            <Style TargetType="local:MainWindow">
+                <Setter Property="FontSize" Value="20"/>
+                <Setter Property="ResizeMode" Value="NoResize"/>
+            </Style>
 
-        <Style x:Key="labeleStyle" TargetType="Label">
-            <Setter Property="FontSize" Value="20"/>
-            <Setter Property="Foreground" Value="DarkBlue"/>
-            <Setter Property="HorizontalContentAlignment" Value="Right"/>
-            <Setter Property="Padding" Value="160,0,0,0"/>
-            <Setter Property="Width" Value="350"/>
-            <Setter Property="Margin" Value="5"/>
-            <Setter Property="Grid.ColumnSpan" Value="2"/>
-        </Style>
+            <Style TargetType="local:RegistrationWindow">
+                <Setter Property="FontSize" Value="20"/>
+                <Setter Property="ResizeMode" Value="NoResize"/>
+            </Style>
 
-        <Style x:Key="labeleAppointmentStyle" TargetType="Label">
-            <Setter Property="FontSize" Value="20"/>
-            <Setter Property="Foreground" Value="DarkBlue"/>
-            <Setter Property="HorizontalContentAlignment" Value="Right"/>
-            <Setter Property="Width" Value="280"/>
-            <Setter Property="Margin" Value="5"/>
-            <Setter Property="Grid.ColumnSpan" Value="2"/>
-        </Style>
+            <Style TargetType="Label">
+                <Setter Property="FontSize" Value="20"/>
+                <Setter Property="Foreground" Value="DarkBlue"/>
+                <Setter Property="HorizontalContentAlignment" Value="Right"/>
+                <Setter Property="Width" Value="350"/>
+                <Setter Property="Margin" Value="5"/>
+                <Setter Property="Grid.ColumnSpan" Value="2"/>
+            </Style>
 
-        <Style x:Key="textBoxAppointmentStyle" TargetType="TextBox">
-            <Setter Property="Foreground" Value="DarkBlue"/>
-            <Setter Property="Background" Value="AliceBlue"/>
-            <Setter Property="FontSize" Value="20"/>
-            <Setter Property="Height" Value="35"/>
-            <Setter Property="Width" Value="370"/>
-            <Setter Property="HorizontalAlignment" Value="Center"/>
-            <Setter Property="Margin" Value="5"/>
-            <Setter Property="Grid.ColumnSpan" Value="3"/>
-        </Style>
+            <Style x:Key="labeleStyle" TargetType="Label">
+                <Setter Property="FontSize" Value="20"/>
+                <Setter Property="Foreground" Value="DarkBlue"/>
+                <Setter Property="HorizontalContentAlignment" Value="Right"/>
+                <Setter Property="Padding" Value="160,0,0,0"/>
+                <Setter Property="Width" Value="350"/>
+                <Setter Property="Margin" Value="5"/>
+                <Setter Property="Grid.ColumnSpan" Value="2"/>
+            </Style>
 
-        <Style x:Key="groupBoxStyle" TargetType="GroupBox">
-            <Setter Property="Foreground" Value="DarkBlue"/>
-            <Setter Property="Background" Value="AliceBlue"/>
-            <Setter Property="FontSize" Value="20"/>
-            <Setter Property="Width" Value="370"/>
-            <Setter Property="HorizontalAlignment" Value="Center"/>
-            <Setter Property="Margin" Value="5"/>
-            <Setter Property="Grid.ColumnSpan" Value="3"/>
-        </Style>
+            <Style x:Key="labeleAppointmentStyle" TargetType="Label">
+                <Setter Property="FontSize" Value="20"/>
+                <Setter Property="Foreground" Value="DarkBlue"/>
+                <Setter Property="HorizontalContentAlignment" Value="Right"/>
+                <Setter Property="Width" Value="280"/>
+                <Setter Property="Margin" Value="5"/>
+                <Setter Property="Grid.ColumnSpan" Value="2"/>
+            </Style>
 
-        <Style x:Key="buttonAppointmentStyle" TargetType="Button">
-            <Setter Property="FontWeight" Value="Normal"/>
-            <Setter Property="FontSize" Value="20"/>
-            <Setter Property="Foreground" Value="DarkBlue"/>
-            <Setter Property="Background" Value="AliceBlue"/>
-            <Setter Property="Grid.ColumnSpan" Value="3"/>
-            <Setter Property="HorizontalAlignment" Value="Center"/>
-            <Setter Property="Margin" Value="5"/>
-            <Setter Property="Width" Value="370"/>
-            <Setter Property="Height" Value="50"/>
-            <Setter Property="Cursor" Value="Hand"/>
-        </Style>
+            <Style x:Key="textBoxAppointmentStyle" TargetType="TextBox">
+                <Setter Property="Foreground" Value="DarkBlue"/>
+                <Setter Property="Background" Value="AliceBlue"/>
+                <Setter Property="FontSize" Value="20"/>
+                <Setter Property="Height" Value="35"/>
+                <Setter Property="Width" Value="370"/>
+                <Setter Property="HorizontalAlignment" Value="Center"/>
+                <Setter Property="Margin" Value="5"/>
+                <Setter Property="Grid.ColumnSpan" Value="3"/>
+            </Style>
 
-        <Style x:Key="comboBoxAppointmentStyle" TargetType="ComboBox">
-            <Setter Property="Foreground" Value="DarkBlue"/>
-            <Setter Property="Background" Value="AliceBlue"/>
-            <Setter Property="FontSize" Value="20"/>
-            <Setter Property="Height" Value="35"/>
-            <Setter Property="Width" Value="370"/>
-            <Setter Property="Margin" Value="5"/>
-            <Setter Property="Grid.ColumnSpan" Value="3"/>
-        </Style>
+            <Style x:Key="groupBoxStyle" TargetType="GroupBox">
+                <Setter Property="Foreground" Value="DarkBlue"/>
+                <Setter Property="Background" Value="AliceBlue"/>
+                <Setter Property="FontSize" Value="20"/>
+                <Setter Property="Width" Value="370"/>
+                <Setter Property="HorizontalAlignment" Value="Center"/>
+                <Setter Property="Margin" Value="5"/>
+                <Setter Property="Grid.ColumnSpan" Value="3"/>
+            </Style>
 
-        <Style TargetType="TextBox">
-            <Setter Property="Foreground" Value="DarkBlue"/>
-            <Setter Property="Background" Value="AliceBlue"/>
-            <Setter Property="HorizontalAlignment" Value="Center"/>
-            <Setter Property="VerticalAlignment" Value="Center"/>
-            <Setter Property="TextAlignment" Value ="Left"/>
-            <Setter Property="Height" Value="35"/>
-            <Setter Property="Width" Value="350"/>
-            <Setter Property="FontSize" Value="20"/>
-            <Setter Property="Margin" Value="5"/>
-            <Setter Property="Grid.ColumnSpan" Value="2"/>
-            <Setter Property="Validation.ErrorTemplate">
-                <Setter.Value>
-                    <ControlTemplate>
-                        <DockPanel>
-                            <Grid DockPanel.Dock="Right" Width="16" Height="16" VerticalAlignment="Center" Margin="3 0 0 0">
-                                <Ellipse Width="16" Height="16" Fill="Red"/>
-                                <Ellipse Width="3" Height="8" VerticalAlignment="Top" HorizontalAlignment="Center" Margin="0 2 0 0" Fill="White"/>
-                                <Ellipse Width="2" Height="2" VerticalAlignment="Bottom" HorizontalAlignment="Center" Margin="0 0 0 2" Fill="White"/>
-                            </Grid>
-                            <Border BorderBrush="Red" BorderThickness="2" CornerRadius="2">
-                                <AdornedElementPlaceholder/>
-                            </Border>
-                        </DockPanel>
-                    </ControlTemplate>
-                </Setter.Value>
-            </Setter>
-            <Style.Triggers>
-                <Trigger Property="Validation.HasError" Value="true">
-                    <Setter Property="ToolTip" Value="{Binding RelativeSource={x:Static RelativeSource.Self}, Path=(Validation.Errors)[0].ErrorContent}"/>
-                </Trigger>
-            </Style.Triggers>
-        </Style>
+            <Style x:Key="buttonAppointmentStyle" TargetType="Button">
+                <Setter Property="FontWeight" Value="Normal"/>
+                <Setter Property="FontSize" Value="20"/>
+                <Setter Property="Foreground" Value="DarkBlue"/>
+                <Setter Property="Background" Value="AliceBlue"/>
+                <Setter Property="Grid.ColumnSpan" Value="3"/>
+                <Setter Property="HorizontalAlignment" Value="Center"/>
+                <Setter Property="Margin" Value="5"/>
+                <Setter Property="Width" Value="370"/>
+                <Setter Property="Height" Value="50"/>
+                <Setter Property="Cursor" Value="Hand"/>
+            </Style>
 
-        <Style x:Key="naviTextBlock" TargetType="TextBlock">
-            <Setter Property="Foreground" Value="DarkBlue"/>
-            <Setter Property="HorizontalAlignment" Value="Center"/>
-            <Setter Property="TextAlignment" Value ="Center"/>
-            <Setter Property="FontWeight" Value="Normal"/>
-            <Setter Property="FontSize" Value="18"/>
-        </Style>
+            <Style x:Key="comboBoxAppointmentStyle" TargetType="ComboBox">
+                <Setter Property="Foreground" Value="DarkBlue"/>
+                <Setter Property="Background" Value="AliceBlue"/>
+                <Setter Property="FontSize" Value="20"/>
+                <Setter Property="Height" Value="35"/>
+                <Setter Property="Width" Value="370"/>
+                <Setter Property="Margin" Value="5"/>
+                <Setter Property="Grid.ColumnSpan" Value="3"/>
+            </Style>
 
-        <Style TargetType="PasswordBox">
-            <Setter Property="Foreground" Value="DarkBlue"/>
-            <Setter Property="Background" Value="AliceBlue"/>
-            <Setter Property="VerticalAlignment" Value="Center"/>
-            <Setter Property="HorizontalAlignment" Value="Center"/>
-            <Setter Property="FontSize" Value="18"/>
-            <Setter Property="Grid.ColumnSpan" Value="2"/>
-            <Setter Property="Height" Value="35"/>
-            <Setter Property="Width" Value="350"/>
-        </Style>
+            <Style TargetType="TextBox">
+                <Setter Property="Foreground" Value="DarkBlue"/>
+                <Setter Property="Background" Value="AliceBlue"/>
+                <Setter Property="HorizontalAlignment" Value="Center"/>
+                <Setter Property="VerticalAlignment" Value="Center"/>
+                <Setter Property="TextAlignment" Value ="Left"/>
+                <Setter Property="Height" Value="35"/>
+                <Setter Property="Width" Value="350"/>
+                <Setter Property="FontSize" Value="20"/>
+                <Setter Property="Margin" Value="5"/>
+                <Setter Property="Grid.ColumnSpan" Value="2"/>
+                <Setter Property="Validation.ErrorTemplate">
+                    <Setter.Value>
+                        <ControlTemplate>
+                            <DockPanel>
+                                <Grid DockPanel.Dock="Right" Width="16" Height="16" VerticalAlignment="Center" Margin="3 0 0 0">
+                                    <Ellipse Width="16" Height="16" Fill="Red"/>
+                                    <Ellipse Width="3" Height="8" VerticalAlignment="Top" HorizontalAlignment="Center" Margin="0 2 0 0" Fill="White"/>
+                                    <Ellipse Width="2" Height="2" VerticalAlignment="Bottom" HorizontalAlignment="Center" Margin="0 0 0 2" Fill="White"/>
+                                </Grid>
+                                <Border BorderBrush="Red" BorderThickness="2" CornerRadius="2">
+                                    <AdornedElementPlaceholder/>
+                                </Border>
+                            </DockPanel>
+                        </ControlTemplate>
+                    </Setter.Value>
+                </Setter>
+                <Style.Triggers>
+                    <Trigger Property="Validation.HasError" Value="true">
+                        <Setter Property="ToolTip" Value="{Binding RelativeSource={x:Static RelativeSource.Self}, Path=(Validation.Errors)[0].ErrorContent}"/>
+                    </Trigger>
+                </Style.Triggers>
+            </Style>
 
-        <Style TargetType="RadioButton">
-            <Setter Property="Foreground" Value="DarkBlue"/>
-            <Setter Property="Background" Value="AliceBlue"/>
-            <Setter Property="HorizontalAlignment" Value="Left"/>
-            <Setter Property="Grid.ColumnSpan" Value="2"/>
-            <Setter Property="Width" Value="100"/>
-            <Setter Property="Margin" Value="2"/>
-            <Setter Property="FontSize" Value="18"/>
-        </Style>
+            <Style x:Key="naviTextBlock" TargetType="TextBlock">
+                <Setter Property="Foreground" Value="DarkBlue"/>
+                <Setter Property="HorizontalAlignment" Value="Center"/>
+                <Setter Property="TextAlignment" Value ="Center"/>
+                <Setter Property="FontWeight" Value="Normal"/>
+                <Setter Property="FontSize" Value="18"/>
+            </Style>
 
-        <Style TargetType="Button">
-            <Setter Property="FontWeight" Value="Normal"/>
-            <Setter Property="FontSize" Value="20"/>
-            <Setter Property="Foreground" Value="DarkBlue"/>
-            <Setter Property="Background" Value="AliceBlue"/>
-            <Setter Property="HorizontalAlignment" Value="Center"/>
-            <Setter Property="Cursor" Value="Hand"/>
-        </Style>
+            <Style TargetType="PasswordBox">
+                <Setter Property="Foreground" Value="DarkBlue"/>
+                <Setter Property="Background" Value="AliceBlue"/>
+                <Setter Property="VerticalAlignment" Value="Center"/>
+                <Setter Property="HorizontalAlignment" Value="Center"/>
+                <Setter Property="FontSize" Value="18"/>
+                <Setter Property="Grid.ColumnSpan" Value="2"/>
+                <Setter Property="Height" Value="35"/>
+                <Setter Property="Width" Value="350"/>
+            </Style>
 
-        <Style x:Key="homePageButton" TargetType="Button">
-            <Setter Property="FontWeight" Value="Normal"/>
-            <Setter Property="FontSize" Value="20"/>
-            <Setter Property="Foreground" Value="DarkBlue"/>
-            <Setter Property="Background" Value="AliceBlue"/>
-            <Setter Property="Grid.ColumnSpan" Value="3"/>
-            <Setter Property="Grid.RowSpan" Value="2"/>
-            <Setter Property="Margin" Value="10"/>
-            <Setter Property="Width" Value="370"/>
-            <Setter Property="Height" Value="60"/>
-            <Setter Property="Cursor" Value="Hand"/>
-        </Style>
+            <Style TargetType="RadioButton">
+                <Setter Property="Foreground" Value="DarkBlue"/>
+                <Setter Property="Background" Value="AliceBlue"/>
+                <Setter Property="HorizontalAlignment" Value="Left"/>
+                <Setter Property="Grid.ColumnSpan" Value="2"/>
+                <Setter Property="Width" Value="100"/>
+                <Setter Property="Margin" Value="2"/>
+                <Setter Property="FontSize" Value="18"/>
+            </Style>
 
-        <Style TargetType="DataGrid">
-            <Setter Property="CanUserResizeColumns" Value="False"/>
-            <Setter Property="CanUserAddRows" Value="False"/>
-            <Setter Property="CanUserAddRows" Value="False"/>
-            <Setter Property="CanUserReorderColumns" Value="False"/>
-            <Setter Property="HorizontalAlignment" Value="Center"/>
-            <Setter Property="AutoGenerateColumns" Value="False"/>
-            <Setter Property="IsReadOnly" Value="True"/>
-            <Setter Property="SelectionMode" Value="Single"/>
-            <Setter Property="Foreground" Value="DarkBlue"/>
-            <Setter Property="FontSize" Value="14"/>
-            <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
-            <Setter Property="RowHeight" Value="25"/>
-        </Style>
+            <Style TargetType="Button">
+                <Setter Property="FontWeight" Value="Normal"/>
+                <Setter Property="FontSize" Value="20"/>
+                <Setter Property="Foreground" Value="DarkBlue"/>
+                <Setter Property="Background" Value="AliceBlue"/>
+                <Setter Property="HorizontalAlignment" Value="Center"/>
+                <Setter Property="Cursor" Value="Hand"/>
+            </Style>
 
-        <Style TargetType="DataGridColumnHeader">
-            <Setter Property="HorizontalContentAlignment" Value="Center"/>
-            <Setter Property="Foreground" Value="DarkBlue"/>
-            <Setter Property="FontSize" Value="16"/>
-        </Style>
+            <Style x:Key="homePageButton" TargetType="Button">
+                <Setter Property="FontWeight" Value="Normal"/>
+                <Setter Property="FontSize" Value="20"/>
+                <Setter Property="Foreground" Value="DarkBlue"/>
+                <Setter Property="Background" Value="AliceBlue"/>
+                <Setter Property="Grid.ColumnSpan" Value="3"/>
+                <Setter Property="Grid.RowSpan" Value="2"/>
+                <Setter Property="Margin" Value="10"/>
+                <Setter Property="Width" Value="370"/>
+                <Setter Property="Height" Value="60"/>
+                <Setter Property="Cursor" Value="Hand"/>
+            </Style>
 
-        <Style x:Key="DataGridCellCentered" TargetType="DataGridCell">
-            <Setter Property="TextBlock.TextAlignment" Value="Center" />
-            <Setter Property="Foreground" Value="DarkBlue"/>
-            <Setter Property="FontSize" Value="16"/>
-        </Style>
+            <Style TargetType="DataGrid">
+                <Setter Property="CanUserResizeColumns" Value="False"/>
+                <Setter Property="CanUserAddRows" Value="False"/>
+                <Setter Property="CanUserAddRows" Value="False"/>
+                <Setter Property="CanUserReorderColumns" Value="False"/>
+                <Setter Property="HorizontalAlignment" Value="Center"/>
+                <Setter Property="AutoGenerateColumns" Value="False"/>
+                <Setter Property="IsReadOnly" Value="True"/>
+                <Setter Property="SelectionMode" Value="Single"/>
+                <Setter Property="Foreground" Value="DarkBlue"/>
+                <Setter Property="FontSize" Value="14"/>
+                <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
+                <Setter Property="RowHeight" Value="25"/>
+            </Style>
 
-        <Style x:Key="dataPickerStyle" TargetType="DatePicker">
-            <Setter Property="Foreground" Value="DarkBlue"/>
-            <Setter Property="Background" Value="AliceBlue"/>
-            <Setter Property="FontSize" Value="20"/>
-            <Setter Property="Height" Value="35"/>
-            <Setter Property="Width" Value="370"/>
-            <Setter Property="HorizontalAlignment" Value="Center"/>
-            <Setter Property="FirstDayOfWeek" Value="Monday"/>
-            <Setter Property="Margin" Value="5"/>
-            <Setter Property="Grid.ColumnSpan" Value="3"/>
-            <Setter Property="IsHitTestVisible" Value="True"/>
-        </Style>
+            <Style TargetType="DataGridColumnHeader">
+                <Setter Property="HorizontalContentAlignment" Value="Center"/>
+                <Setter Property="Foreground" Value="DarkBlue"/>
+                <Setter Property="FontSize" Value="16"/>
+            </Style>
 
-        <Style x:Key="dataPickerRegistration" TargetType="DatePicker">
-            <Setter Property="Foreground" Value="DarkBlue"/>
-            <Setter Property="Background" Value="AliceBlue"/>
-            <Setter Property="HorizontalAlignment" Value="Center"/>
-            <Setter Property="VerticalAlignment" Value="Center"/>
-            <Setter Property="Height" Value="35"/>
-            <Setter Property="Width" Value="350"/>
-            <Setter Property="FontSize" Value="20"/>
-            <Setter Property="Margin" Value="5"/>
-            <Setter Property="Grid.ColumnSpan" Value="2"/>
-            <Setter Property="FontSize" Value="20"/>
-            <Setter Property="HorizontalAlignment" Value="Center"/>
-            <Setter Property="FirstDayOfWeek" Value="Monday"/>
-            <Setter Property="IsHitTestVisible" Value="True"/>
-        </Style>
+            <Style x:Key="DataGridCellCentered" TargetType="DataGridCell">
+                <Setter Property="TextBlock.TextAlignment" Value="Center" />
+                <Setter Property="Foreground" Value="DarkBlue"/>
+                <Setter Property="FontSize" Value="16"/>
+            </Style>
 
-        <Style x:Key="comboBoxItem"  TargetType="ComboBoxItem">
-            <Setter Property="Foreground" Value="DarkBlue"/>
-            <Setter Property="Background" Value="AliceBlue"/>
-            <Setter Property="SnapsToDevicePixels" Value="True"/>
-            <Setter Property="OverridesDefaultStyle" Value="True"/>
-            <Setter Property="FontSize" Value="20"/>
-        </Style>
+            <Style x:Key="dataPickerStyle" TargetType="DatePicker">
+                <Setter Property="Foreground" Value="DarkBlue"/>
+                <Setter Property="Background" Value="AliceBlue"/>
+                <Setter Property="FontSize" Value="20"/>
+                <Setter Property="Height" Value="35"/>
+                <Setter Property="Width" Value="370"/>
+                <Setter Property="HorizontalAlignment" Value="Center"/>
+                <Setter Property="FirstDayOfWeek" Value="Monday"/>
+                <Setter Property="Margin" Value="5"/>
+                <Setter Property="Grid.ColumnSpan" Value="3"/>
+                <Setter Property="IsHitTestVisible" Value="True"/>
+            </Style>
+
+            <Style x:Key="dataPickerRegistration" TargetType="DatePicker">
+                 <Setter Property="Foreground" Value="DarkBlue"/>
+                 <Setter Property="Background" Value="AliceBlue"/>
+                 <Setter Property="HorizontalAlignment" Value="Center"/>
+                 <Setter Property="VerticalAlignment" Value="Center"/>
+                 <Setter Property="Height" Value="35"/>
+                 <Setter Property="Width" Value="350"/>
+                 <Setter Property="FontSize" Value="20"/>
+                 <Setter Property="Margin" Value="5"/>
+                 <Setter Property="Grid.ColumnSpan" Value="2"/>
+                 <Setter Property="FontSize" Value="20"/>
+                 <Setter Property="HorizontalAlignment" Value="Center"/>
+                 <Setter Property="FirstDayOfWeek" Value="Monday"/>
+                 <Setter Property="IsHitTestVisible" Value="True"/>
+            </Style>
+
+            <Style x:Key="comboBoxItem"  TargetType="ComboBoxItem">
+                  <Setter Property="Foreground" Value="DarkBlue"/>
+                  <Setter Property="Background" Value="AliceBlue"/>
+                  <Setter Property="SnapsToDevicePixels" Value="True"/>
+                  <Setter Property="OverridesDefaultStyle" Value="True"/>
+                  <Setter Property="FontSize" Value="20"/>
+            </Style>
+        </ResourceDictionary>
     </Application.Resources>
 </Application>

--- a/HealthcareSystem/PatientFrontend/PatientFrontend.csproj
+++ b/HealthcareSystem/PatientFrontend/PatientFrontend.csproj
@@ -14,6 +14,8 @@
     <WarningLevel>4</WarningLevel>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Deterministic>true</Deterministic>
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -35,6 +37,12 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="MaterialDesignColors, Version=1.2.7.1979, Culture=neutral, PublicKeyToken=df2a72020bd7962a, processorArchitecture=MSIL">
+      <HintPath>..\packages\MaterialDesignColors.1.2.7\lib\net45\MaterialDesignColors.dll</HintPath>
+    </Reference>
+    <Reference Include="MaterialDesignThemes.Wpf, Version=3.2.0.1979, Culture=neutral, PublicKeyToken=df2a72020bd7962a, processorArchitecture=MSIL">
+      <HintPath>..\packages\MaterialDesignThemes.3.2.0\lib\net45\MaterialDesignThemes.Wpf.dll</HintPath>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
@@ -471,5 +479,18 @@
   <ItemGroup>
     <Resource Include="Resources\Images\vector.png" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\GraphicalEditor\GraphicalEditor.csproj">
+      <Project>{b1629766-3bec-4edd-9328-d1fb4530cbd1}</Project>
+      <Name>GraphicalEditor</Name>
+    </ProjectReference>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Import Project="..\packages\MaterialDesignThemes.3.2.0\build\MaterialDesignThemes.targets" Condition="Exists('..\packages\MaterialDesignThemes.3.2.0\build\MaterialDesignThemes.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\MaterialDesignThemes.3.2.0\build\MaterialDesignThemes.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MaterialDesignThemes.3.2.0\build\MaterialDesignThemes.targets'))" />
+  </Target>
 </Project>

--- a/HealthcareSystem/PatientFrontend/View/HomePageWindow.xaml
+++ b/HealthcareSystem/PatientFrontend/View/HomePageWindow.xaml
@@ -1,10 +1,18 @@
 ﻿<Window x:Class="ZdravoKorporacija.HomePageWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:ZdravoKorporacija"
         mc:Ignorable="d"
+        TextElement.Foreground="{DynamicResource MaterialDesignBody}"
+        TextElement.FontWeight="Regular"
+        TextElement.FontSize="13"
+        TextOptions.TextFormattingMode="Ideal"
+        TextOptions.TextRenderingMode="Auto"
+        FontFamily="{DynamicResource MaterialDesignFont}"
+        
         Title="Zdravo Korporacija"  
         Height="665" Width="960"
         Background="Azure"
@@ -21,6 +29,8 @@
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="30"/>
             <RowDefinition Height="70"/>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
             <RowDefinition Height="Auto"/>
@@ -86,6 +96,8 @@
         <Button x:Name="buttonReviewReport" Content="Izveštaj terapije na sedmičnom nivou" Grid.Column="1" Grid.Row="12" Style="{StaticResource ResourceKey=homePageButton}" Click="buttonReviewReport_Click" ToolTip="Za prelazak na pregledanje izveštaja o rasporedu terapiji na sedmičnom nivou kliknite dugme I"/>
 
         <Button x:Name="buttonReviewNotifications" Content="Pregledajte obaveštenja" Grid.Column="4" Grid.Row="12" Style="{StaticResource ResourceKey=homePageButton}" Click="buttonReviewNotifications_Click" ToolTip="Za prelazak na pregledanje obaveštenja kliknite dugme O"/>
+
+        <Button x:Name="buttonShowGraphicalEditor" Content="Prikažite editor i mapu bolnice" Grid.Column="4" Grid.Row="14" Style="{StaticResource ResourceKey=homePageButton}" Click="buttonShowGraphicalEditor_Click" ToolTip="Za otvaranje grafičkog editora sa mapom bolnice kliknite dugme E"/>
         <!--#endregion-->
     </Grid>
 </Window>

--- a/HealthcareSystem/PatientFrontend/View/HomePageWindow.xaml.cs
+++ b/HealthcareSystem/PatientFrontend/View/HomePageWindow.xaml.cs
@@ -105,6 +105,12 @@ namespace ZdravoKorporacija
             this.Close();
         }
 
+        private void buttonShowGraphicalEditor_Click(object sender, RoutedEventArgs e)
+        {
+            GraphicalEditor.MainWindow graphicalEditorMainWindow = new GraphicalEditor.MainWindow();
+            graphicalEditorMainWindow.ShowDialog();
+        }
+
         private void Window_KeyDown(object sender, KeyEventArgs e)
         {
             if (e.Key == Key.M)
@@ -166,6 +172,11 @@ namespace ZdravoKorporacija
                 SurveyWindow surveyWindow = new SurveyWindow();
                 surveyWindow.Show();
                 this.Close();
+            }
+            else if (e.Key == Key.E)
+            {
+                GraphicalEditor.MainWindow graphicalEditorMainWindow = new GraphicalEditor.MainWindow();
+                graphicalEditorMainWindow.ShowDialog();
             }
         }
     }

--- a/HealthcareSystem/PatientFrontend/packages.config
+++ b/HealthcareSystem/PatientFrontend/packages.config
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="MaterialDesignColors" version="1.2.7" targetFramework="net472" />
+  <package id="MaterialDesignThemes" version="3.2.0" targetFramework="net472" />
   <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net472" />
   <package id="Syncfusion.Compression.Base" version="18.1.0.54" targetFramework="net472" />
   <package id="Syncfusion.Licensing" version="18.1.0.54" targetFramework="net472" />


### PR DESCRIPTION
- On this branch I have connected Patient WPF with Graphical Editor, so now on button click in Patient WPF you can open GraphicalEditor in separate window
- I needed to install MaterialDesign to Patient WPF because it calls Graphical Editor (which uses MaterialDesign)

-This is mostly XAML code and very small modifications so there is not much to review...