### PR TITLE
feat[g10]: Object info editing restriction - Only manager can edit info

### DIFF
--- a/HealthcareSystem/DoctorFrontend/HomePage.xaml.cs
+++ b/HealthcareSystem/DoctorFrontend/HomePage.xaml.cs
@@ -122,7 +122,7 @@ namespace WpfApp1
 
         private void Navigation_Graphical_Editor_Click(object sender, RoutedEventArgs e)
         {
-            GraphicalEditor.MainWindow graphicalEditorMainWindow = new GraphicalEditor.MainWindow();
+            GraphicalEditor.MainWindow graphicalEditorMainWindow = new GraphicalEditor.MainWindow("Doctor");
             graphicalEditorMainWindow.ShowDialog();
         }
         private void btn1_Click(object sender, RoutedEventArgs e)

--- a/HealthcareSystem/GraphicalEditor/MainWindow.xaml.cs
+++ b/HealthcareSystem/GraphicalEditor/MainWindow.xaml.cs
@@ -34,6 +34,7 @@ namespace GraphicalEditor
         public static Canvas _canvas;
         private MapObjectController _mapObjectController;
         public static List<MapObject> _allMapObjects;
+        private string _currentUserRole;
 
 
         private IRepository _fileRepository;
@@ -108,6 +109,25 @@ namespace GraphicalEditor
             ChangeEditButtonVisibility();
         }
 
+        public MainWindow(string currentUserRole)
+        {
+            InitializeComponent();
+            this.DataContext = this;
+            _currentUserRole = currentUserRole;
+            _canvas = this.Canvas;
+            _fileRepository = new FileRepository("test.json");
+            _mapObjectController = new MapObjectController(new MapObjectServices(_fileRepository));
+            _allMapObjects = new List<MapObject>();
+            this.DataContext = this;
+            MockupObjects mockupObjects = new MockupObjects();
+            _allMapObjects = mockupObjects.AllMapObjects;
+            //uncomment when you dont have anything in file
+            saveMap();
+            LoadInitialMapOnCanvas();
+            ChangeEditButtonVisibility();
+        }
+
+
         private void LoadInitialMapOnCanvas()
         {
             _allMapObjects = _fileRepository.LoadMap().ToList();
@@ -145,23 +165,16 @@ namespace GraphicalEditor
             EditMode = !EditMode;
         }
 
-        public void ChangeEditButtonVisibility() {
-            if (_selectedMapObject == null)
-            {
-                EditObjectButton.Visibility = Visibility.Hidden;
-                SaveButton.Visibility = Visibility.Hidden;
-                EditMode = false ;
-            }
-            else
+        public void ChangeEditButtonVisibility()
+        {
+            EditObjectButton.Visibility = Visibility.Hidden;
+            EditMode = false;
+
+            if (!String.IsNullOrEmpty(_currentUserRole) && _currentUserRole.Equals("Manager") && (_selectedMapObject != null))
             {
                 if (_selectedMapObject.MapObjectEntity.MapObjectType.TypeOfMapObject != TypeOfMapObject.ROAD)
                 {
                     EditObjectButton.Visibility = Visibility.Visible;
-                    SaveButton.Visibility = Visibility.Visible;
-                }
-                else {
-                    EditObjectButton.Visibility = Visibility.Hidden;
-                    SaveButton.Visibility = Visibility.Hidden;
                 }
             }
         }

--- a/HealthcareSystem/ManagerFrontend/MainWindow.xaml.cs
+++ b/HealthcareSystem/ManagerFrontend/MainWindow.xaml.cs
@@ -212,7 +212,7 @@ namespace Clinic_Health
 
         private void Navigation_Graphical_Editor_Click(object sender, RoutedEventArgs e)
         {
-			GraphicalEditor.MainWindow graphicalEditorMainWindow = new GraphicalEditor.MainWindow();
+			GraphicalEditor.MainWindow graphicalEditorMainWindow = new GraphicalEditor.MainWindow("Manager");
 			graphicalEditorMainWindow.ShowDialog();
         }
     }

--- a/HealthcareSystem/PatientFrontend/View/HomePageWindow.xaml.cs
+++ b/HealthcareSystem/PatientFrontend/View/HomePageWindow.xaml.cs
@@ -107,7 +107,7 @@ namespace ZdravoKorporacija
 
         private void buttonShowGraphicalEditor_Click(object sender, RoutedEventArgs e)
         {
-            GraphicalEditor.MainWindow graphicalEditorMainWindow = new GraphicalEditor.MainWindow();
+            GraphicalEditor.MainWindow graphicalEditorMainWindow = new GraphicalEditor.MainWindow("Patient");
             graphicalEditorMainWindow.ShowDialog();
         }
 
@@ -175,7 +175,7 @@ namespace ZdravoKorporacija
             }
             else if (e.Key == Key.E)
             {
-                GraphicalEditor.MainWindow graphicalEditorMainWindow = new GraphicalEditor.MainWindow();
+                GraphicalEditor.MainWindow graphicalEditorMainWindow = new GraphicalEditor.MainWindow("Patient");
                 graphicalEditorMainWindow.ShowDialog();
             }
         }

--- a/HealthcareSystem/SecretaryFrontend/View/MainWindow.xaml.cs
+++ b/HealthcareSystem/SecretaryFrontend/View/MainWindow.xaml.cs
@@ -93,7 +93,7 @@ namespace ProjekatZdravoKorporacija
 
         private void HospitalMap_PreviewMouseLeftButtonUp(object sender, MouseButtonEventArgs e)
         {
-            GraphicalEditor.MainWindow graphicalEditorMainWindow = new GraphicalEditor.MainWindow();
+            GraphicalEditor.MainWindow graphicalEditorMainWindow = new GraphicalEditor.MainWindow("Secretary");
             graphicalEditorMainWindow.ShowDialog();
         }
     }


### PR DESCRIPTION
Object information can be changed only by Manager. On this branch I have implemented code for editing restriction:
- User role is determined through WPF which called Graphical Editor project
- Only Manager role can see button for editing object info. Button for editing is hidden for other roles

This logic will make it very easy for us to make patient restriction (g13) later. 