### PR TITLE
gui[g-general]: Implemented menu, GUI Panels for searches, object equipment and medicine overview

### DIFF
--- a/HealthcareSystem/GraphicalEditor/App.xaml
+++ b/HealthcareSystem/GraphicalEditor/App.xaml
@@ -1,8 +1,9 @@
-﻿<Application x:Class="GraphicalEditor.App"
-             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:local="clr-namespace:GraphicalEditor"
-             StartupUri="MainWindow.xaml">
+﻿<Application
+    x:Class="GraphicalEditor.App"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="clr-namespace:GraphicalEditor"
+    StartupUri="MainWindow.xaml">
     <Application.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>

--- a/HealthcareSystem/GraphicalEditor/MainWindow.xaml
+++ b/HealthcareSystem/GraphicalEditor/MainWindow.xaml
@@ -1,39 +1,44 @@
-﻿<Window x:Class="GraphicalEditor.MainWindow"
-        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-        xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
-        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-        xmlns:local="clr-namespace:GraphicalEditor"
-        mc:Ignorable="d"
-        WindowState="Maximized"
-        TextElement.Foreground="{DynamicResource MaterialDesignBody}"
-        TextElement.FontWeight="Regular"
-        TextElement.FontSize="13"
-        TextOptions.TextFormattingMode="Ideal"
-        TextOptions.TextRenderingMode="Auto"
-        Background="{DynamicResource MaterialDesignPaper}"
-        FontFamily="{DynamicResource MaterialDesignFont}"
-        Title="Grafički editor sa mapom bolnice" Height="800" Width="1500" WindowStartupLocation="CenterScreen">
+﻿<Window
+    x:Class="GraphicalEditor.MainWindow"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:local="clr-namespace:GraphicalEditor"
+    xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    Title="Grafički editor sa mapom bolnice"
+    Width="1500"
+    Height="800"
+    Background="{DynamicResource MaterialDesignPaper}"
+    FontFamily="{DynamicResource MaterialDesignFont}"
+    TextElement.FontSize="13"
+    TextElement.FontWeight="Regular"
+    TextElement.Foreground="{DynamicResource MaterialDesignBody}"
+    TextOptions.TextFormattingMode="Ideal"
+    TextOptions.TextRenderingMode="Auto"
+    WindowStartupLocation="CenterScreen"
+    WindowState="Maximized"
+    mc:Ignorable="d">
 
-   
+
 
 
 
 
 
     <DockPanel>
-        <StackPanel DockPanel.Dock="Left" Margin="20 20 0 0" >
-            <Canvas x:Name="Canvas" Height="700" Width="1086" 
-                HorizontalAlignment="Center" 
-                VerticalAlignment="Bottom" 
+        <StackPanel Margin="20,20,0,0" DockPanel.Dock="Left">
+            <Canvas
+                x:Name="Canvas"
+                Width="1086"
+                Height="700"
+                HorizontalAlignment="Center"
+                VerticalAlignment="Bottom"
                 Background="#D9FFBF"
-                MouseDown="Canvas_MouseDown" 
-                MouseMove="Canvas_MouseMove">
+                MouseDown="Canvas_MouseDown"
+                MouseMove="Canvas_MouseMove" />
 
-            </Canvas>
-
-            <Grid Margin="0 5 0 0">
+            <Grid Margin="0,5,0,0">
                 <Grid.RowDefinitions>
                     <RowDefinition Height="30" />
                     <RowDefinition Height="30" />
@@ -47,146 +52,164 @@
                     <ColumnDefinition Width="*" />
                 </Grid.ColumnDefinitions>
 
-                <WrapPanel Grid.Row="0" Grid.Column="0"
-                           VerticalAlignment="Center">
+                <WrapPanel
+                    Grid.Row="0"
+                    Grid.Column="0"
+                    VerticalAlignment="Center">
                     <Ellipse
                         Width="18"
                         Height="18"
                         Fill="White"
                         Stroke="Gray"
-                        StrokeThickness="1"/>
-                    <TextBlock 
-                        Margin="5 -1 0 0"
-                        FontSize="16"
-                        VerticalAlignment="Center">
+                        StrokeThickness="1" />
+                    <TextBlock
+                        Margin="5,-1,0,0"
+                        VerticalAlignment="Center"
+                        FontSize="16">
                         Zgrada
                     </TextBlock>
                 </WrapPanel>
 
-                <WrapPanel Grid.Row="0" Grid.Column="1"
-                           VerticalAlignment="Center">
+                <WrapPanel
+                    Grid.Row="0"
+                    Grid.Column="1"
+                    VerticalAlignment="Center">
                     <Ellipse
                         Width="18"
                         Height="18"
                         Fill="Lavender"
                         Stroke="Gray"
-                        StrokeThickness="1"/>
-                    <TextBlock 
-                        Margin="5 -1 0 0"
-                        FontSize="16"
-                        VerticalAlignment="Center">
+                        StrokeThickness="1" />
+                    <TextBlock
+                        Margin="5,-1,0,0"
+                        VerticalAlignment="Center"
+                        FontSize="16">
                         Sala za pregled
                     </TextBlock>
                 </WrapPanel>
 
-                <WrapPanel Grid.Row="0" Grid.Column="2"
-                           VerticalAlignment="Center">
+                <WrapPanel
+                    Grid.Row="0"
+                    Grid.Column="2"
+                    VerticalAlignment="Center">
                     <Ellipse
                         Width="18"
                         Height="18"
                         Fill="LightCyan"
                         Stroke="Gray"
-                        StrokeThickness="1"/>
-                    <TextBlock 
-                        Margin="5 -1 0 0"
-                        FontSize="16"
-                        VerticalAlignment="Center">
+                        StrokeThickness="1" />
+                    <TextBlock
+                        Margin="5,-1,0,0"
+                        VerticalAlignment="Center"
+                        FontSize="16">
                         Operaciona sala
                     </TextBlock>
                 </WrapPanel>
 
-                <WrapPanel Grid.Row="0" Grid.Column="3"
-                           VerticalAlignment="Center">
+                <WrapPanel
+                    Grid.Row="0"
+                    Grid.Column="3"
+                    VerticalAlignment="Center">
                     <Ellipse
                         Width="18"
                         Height="18"
                         Fill="Honeydew"
                         Stroke="Gray"
-                        StrokeThickness="1"/>
-                    <TextBlock 
-                        Margin="5 -1 0 0"
-                        FontSize="16"
-                        VerticalAlignment="Center">
+                        StrokeThickness="1" />
+                    <TextBlock
+                        Margin="5,-1,0,0"
+                        VerticalAlignment="Center"
+                        FontSize="16">
                         Čekaonica
                     </TextBlock>
                 </WrapPanel>
 
-                <WrapPanel Grid.Row="0" Grid.Column="4"
-                           VerticalAlignment="Center">
+                <WrapPanel
+                    Grid.Row="0"
+                    Grid.Column="4"
+                    VerticalAlignment="Center">
                     <Ellipse
                         Width="18"
                         Height="18"
                         Fill="CornflowerBlue"
                         Stroke="Gray"
-                        StrokeThickness="1"/>
-                    <TextBlock 
-                        Margin="5 -1 0 0"
-                        FontSize="16"
-                        VerticalAlignment="Center">
+                        StrokeThickness="1" />
+                    <TextBlock
+                        Margin="5,-1,0,0"
+                        VerticalAlignment="Center"
+                        FontSize="16">
                         Parking
                     </TextBlock>
                 </WrapPanel>
 
-                <WrapPanel Grid.Row="1" Grid.Column="0"
-                           VerticalAlignment="Center">
+                <WrapPanel
+                    Grid.Row="1"
+                    Grid.Column="0"
+                    VerticalAlignment="Center">
                     <Ellipse
                         Width="18"
                         Height="18"
                         Fill="BlanchedAlmond"
                         Stroke="Gray"
-                        StrokeThickness="1"/>
-                    <TextBlock 
-                        Margin="5 -1 0 0"
-                        FontSize="16"
-                        VerticalAlignment="Center">
+                        StrokeThickness="1" />
+                    <TextBlock
+                        Margin="5,-1,0,0"
+                        VerticalAlignment="Center"
+                        FontSize="16">
                         Restoran
                     </TextBlock>
                 </WrapPanel>
 
-                <WrapPanel Grid.Row="1" Grid.Column="1"
-                           VerticalAlignment="Center">
+                <WrapPanel
+                    Grid.Row="1"
+                    Grid.Column="1"
+                    VerticalAlignment="Center">
                     <Ellipse
                         Width="18"
                         Height="18"
                         Fill="Aquamarine"
                         Stroke="Gray"
-                        StrokeThickness="1"/>
-                    <TextBlock 
-                        Margin="5 -1 0 0"
-                        FontSize="16"
-                        VerticalAlignment="Center">
+                        StrokeThickness="1" />
+                    <TextBlock
+                        Margin="5,-1,0,0"
+                        VerticalAlignment="Center"
+                        FontSize="16">
                         Soba za oporavak
                     </TextBlock>
                 </WrapPanel>
 
-                <WrapPanel Grid.Row="1" Grid.Column="2"
-                           VerticalAlignment="Center">
+                <WrapPanel
+                    Grid.Row="1"
+                    Grid.Column="2"
+                    VerticalAlignment="Center">
                     <Ellipse
                         Width="18"
                         Height="18"
                         Fill="LightYellow"
                         Stroke="Gray"
-                        StrokeThickness="1"/>
-                    <TextBlock 
-                        Margin="5 -1 0 0"
-                        FontSize="16"
-                        VerticalAlignment="Center">
+                        StrokeThickness="1" />
+                    <TextBlock
+                        Margin="5,-1,0,0"
+                        VerticalAlignment="Center"
+                        FontSize="16">
                         WC
                     </TextBlock>
                 </WrapPanel>
 
-                <WrapPanel Grid.Row="1" Grid.Column="3"
-                           VerticalAlignment="Center">
+                <WrapPanel
+                    Grid.Row="1"
+                    Grid.Column="3"
+                    VerticalAlignment="Center">
                     <Ellipse
                         Width="18"
                         Height="18"
                         Fill="LightGray"
                         Stroke="Gray"
-                        StrokeThickness="1"/>
-                    <TextBlock 
-                        Margin="5 -1 0 0"
-                        FontSize="16"
-                        VerticalAlignment="Center">
+                        StrokeThickness="1" />
+                    <TextBlock
+                        Margin="5,-1,0,0"
+                        VerticalAlignment="Center"
+                        FontSize="16">
                         Put
                     </TextBlock>
                 </WrapPanel>
@@ -194,9 +217,10 @@
             </Grid>
         </StackPanel>
 
-        <Border DockPanel.Dock="Right"
-                Margin="0 20 0 50"
-                Padding="10 0 10 0">
+        <Border
+            Margin="0,20,0,50"
+            Padding="10,0,10,0"
+            DockPanel.Dock="Right">
             <StackPanel x:Name="InformationDisplay">
 
                 <StackPanel.Resources>
@@ -223,9 +247,11 @@
                         </Style.Triggers>
                     </Style>
 
-                    <Style x:Key="EditingModeMenuButton" TargetType="Button" 
-                            BasedOn="{StaticResource MaterialDesignRaisedButton}" >
-                    <Style.Triggers>
+                    <Style
+                        x:Key="EditingModeMenuButton"
+                        BasedOn="{StaticResource MaterialDesignRaisedButton}"
+                        TargetType="Button">
+                        <Style.Triggers>
                             <DataTrigger Binding="{Binding EditMode}" Value="False">
                                 <Setter Property="Visibility" Value="Visible" />
                             </DataTrigger>
@@ -257,52 +283,187 @@
                         </Style.Triggers>
                     </Style>
 
+                    <Style x:Key="NoSelectionObjectInfoPanel" TargetType="StackPanel">
+                        <!--  Show panel regularly  -->
+                        <Setter Property="Visibility" Value="Visible" />
+                        <Style.Triggers>
+                            <!--  Hide panel if none of the objects is selected (selected object is null)  -->
+                            <DataTrigger Binding="{Binding DisplayMapObject}" Value="{x:Null}">
+                                <Setter Property="Visibility" Value="Collapsed" />
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+
+
+                    <Style x:Key="ObjectInfoPanelSelectedFromMenu" TargetType="StackPanel">
+                        <Setter Property="Visibility" Value="Collapsed" />
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding SelectedMenuOptionIndex}" Value="0">
+                                <Setter Property="Visibility" Value="Visible" />
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+
+                    <Style x:Key="SearchObjectsPanelSelectedFromMenu" TargetType="StackPanel">
+                        <Setter Property="Visibility" Value="Collapsed" />
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding SelectedMenuOptionIndex}" Value="1">
+                                <Setter Property="Visibility" Value="Visible" />
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+
+                    <Style x:Key="SearchEquipmentAndMedicinePanelSelectedFromMenu" TargetType="StackPanel">
+                        <Setter Property="Visibility" Value="Collapsed" />
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding SelectedMenuOptionIndex}" Value="2">
+                                <Setter Property="Visibility" Value="Visible" />
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
+
+                    <Style x:Key="SearchAppointmentsPanelSelectedFromMenu" TargetType="StackPanel">
+                        <Setter Property="Visibility" Value="Collapsed" />
+                        <Style.Triggers>
+                            <DataTrigger Binding="{Binding SelectedMenuOptionIndex}" Value="3">
+                                <Setter Property="Visibility" Value="Visible" />
+                            </DataTrigger>
+                        </Style.Triggers>
+                    </Style>
                 </StackPanel.Resources>
 
 
                 <StackPanel>
-                    <!--MENU-->
-                    <StackPanel x:Name="MenuPanel" VerticalAlignment="Top" Style="{StaticResource MenuOpened}">
+                    <!--  MENU  -->
+                    <StackPanel
+                        x:Name="MenuPanel"
+                        VerticalAlignment="Top"
+                        Style="{StaticResource MenuOpened}">
                         <Grid>
-                            <Button x:Name="CloseMenuButton" Width="Auto" Height="Auto" Background="{x:Null}" BorderBrush="{x:Null}"  VerticalAlignment="Top" HorizontalAlignment="Right" Click="CloseMenuButton_Click">
-                                <materialDesign:PackIcon Kind ="Close" Foreground="MediumPurple" Width="50" Height="50"  />
+                            <Button
+                                x:Name="CloseMenuButton"
+                                Width="Auto"
+                                Height="Auto"
+                                HorizontalAlignment="Right"
+                                VerticalAlignment="Top"
+                                Background="{x:Null}"
+                                BorderBrush="{x:Null}"
+                                Click="CloseMenuButton_Click">
+                                <materialDesign:PackIcon
+                                    Width="50"
+                                    Height="50"
+                                    Foreground="MediumPurple"
+                                    Kind="Close" />
                             </Button>
                         </Grid>
                         <StackPanel>
-                            <ListView x:Name="ListViewExtendMenu" Foreground="#FF313131" ScrollViewer.HorizontalScrollBarVisibility="Disabled" FontFamily="Roboto" FontSize="18" SelectionChanged="ListViewExtendMenu_SelectionChanged">
+                            <ListView
+                                x:Name="ListViewExtendMenu"
+                                FontFamily="Roboto"
+                                FontSize="18"
+                                Foreground="#FF313131"
+                                ScrollViewer.HorizontalScrollBarVisibility="Disabled"
+                                SelectedIndex="{Binding SelectedMenuOptionIndex}"
+                                SelectionChanged="ListViewExtendMenu_SelectionChanged">
 
-                                <ListViewItem Height="60" Padding="0">
-                                    <StackPanel Orientation="Horizontal" Margin="10 0">
-                                        <materialDesign:PackIcon Kind="FileDocumentEdit" Foreground="MediumPurple" Width="30" Height="30" Margin="5" VerticalAlignment="Center"/>
-                                        <TextBlock Text="Prikaz i izmena informacija" Foreground="MediumPurple" VerticalAlignment="Center" Margin="10"/>
+                                <ListViewItem
+                                    x:Name="DisplayAndEditObjectsMenuItem"
+                                    Height="60"
+                                    Padding="0">
+                                    <StackPanel Margin="10,0" Orientation="Horizontal">
+                                        <materialDesign:PackIcon
+                                            Width="30"
+                                            Height="30"
+                                            Margin="5"
+                                            VerticalAlignment="Center"
+                                            Foreground="MediumPurple"
+                                            Kind="FileDocumentEdit" />
+                                        <TextBlock
+                                            Margin="10"
+                                            VerticalAlignment="Center"
+                                            Foreground="MediumPurple"
+                                            Text="Prikaz i izmena informacija" />
+                                    </StackPanel>
+                                </ListViewItem>
+
+                                <ListViewItem
+                                    x:Name="SearchObjectsMenuItem"
+                                    Height="60"
+                                    Padding="0">
+                                    <StackPanel Margin="10,0" Orientation="Horizontal">
+                                        <materialDesign:PackIcon
+                                            Width="30"
+                                            Height="30"
+                                            Margin="5"
+                                            VerticalAlignment="Center"
+                                            Foreground="MediumPurple"
+                                            Kind="MapSearchOutline" />
+                                        <TextBlock
+                                            Margin="10"
+                                            VerticalAlignment="Center"
+                                            Foreground="MediumPurple"
+                                            Text="Pretraga objekata" />
+                                    </StackPanel>
+                                </ListViewItem>
+
+                                <ListViewItem
+                                    x:Name="SearchEquipmentAndMedicineMenuItem"
+                                    Height="60"
+                                    Padding="0">
+                                    <StackPanel
+                                        Margin="10,0"
+                                        HorizontalAlignment="Left"
+                                        Orientation="Horizontal">
+                                        <materialDesign:PackIcon
+                                            Width="30"
+                                            Height="30"
+                                            Margin="5,0,0,0"
+                                            VerticalAlignment="Center"
+                                            Foreground="MediumPurple"
+                                            Kind="SearchPlus" />
+                                        <TextBlock
+                                            Margin="10"
+                                            VerticalAlignment="Center"
+                                            FontSize="18"
+                                            Foreground="MediumPurple"
+                                            Text=" Pretraga opreme i lekova" />
+                                    </StackPanel>
+                                </ListViewItem>
+
+                                <ListViewItem
+                                    x:Name="SearchAppointmentsMenuItem"
+                                    Height="60"
+                                    Padding="0">
+                                    <StackPanel Margin="10,0" Orientation="Horizontal">
+                                        <materialDesign:PackIcon
+                                            Width="30"
+                                            Height="30"
+                                            Margin="5"
+                                            VerticalAlignment="Center"
+                                            Foreground="MediumPurple"
+                                            Kind="CalendarClock" />
+                                        <TextBlock
+                                            Margin="10"
+                                            VerticalAlignment="Center"
+                                            Foreground="MediumPurple"
+                                            Text="Pretraga termina" />
                                     </StackPanel>
                                 </ListViewItem>
 
                                 <ListViewItem Height="60" Padding="0">
-                                    <StackPanel Orientation="Horizontal" Margin="10 0">
-                                        <materialDesign:PackIcon Kind="MapSearchOutline" Foreground="MediumPurple" Width="30" Height="30" Margin="5" VerticalAlignment="Center"/>
-                                        <TextBlock Text="Pretraga objekata" Foreground="MediumPurple" VerticalAlignment="Center"  Margin="10"/>
-                                    </StackPanel>
-                                </ListViewItem>
-
-                                <ListViewItem Height="60" Padding="0">
-                                    <StackPanel Orientation="Horizontal" HorizontalAlignment="Left" Margin="10 0">
-                                        <materialDesign:PackIcon Kind="SearchPlus" Foreground="MediumPurple" Width="30" Height="30" Margin="5,0,0,0" VerticalAlignment="Center"/>
-                                        <TextBlock Text=" Pretraga lekova i opreme" FontSize="18" Foreground="MediumPurple" VerticalAlignment="Center" Margin="10"/>
-                                    </StackPanel>
-                                </ListViewItem>
-
-                                <ListViewItem Height="60" Padding="0">
-                                    <StackPanel Orientation="Horizontal" Margin="10 0">
-                                        <materialDesign:PackIcon Kind="CalendarClock" Foreground="MediumPurple" Width="30" Height="30" Margin="5" VerticalAlignment="Center"/>
-                                        <TextBlock Text="Pretraga termina" Foreground="MediumPurple" VerticalAlignment="Center" Margin="10"/>
-                                    </StackPanel>
-                                </ListViewItem>
-
-                                <ListViewItem Height="60" Padding="0">
-                                    <StackPanel Orientation="Horizontal" Margin="10 0">
-                                        <materialDesign:PackIcon Kind="InfoCircle" Foreground="MediumPurple" Width="30" Height="30" Margin="5" VerticalAlignment="Center"/>
-                                        <TextBlock Text="O aplikaciji" Foreground="MediumPurple" VerticalAlignment="Center" Margin="10"/>
+                                    <StackPanel Margin="10,0" Orientation="Horizontal">
+                                        <materialDesign:PackIcon
+                                            Width="30"
+                                            Height="30"
+                                            Margin="5"
+                                            VerticalAlignment="Center"
+                                            Foreground="MediumPurple"
+                                            Kind="InfoCircle" />
+                                        <TextBlock
+                                            Margin="10"
+                                            VerticalAlignment="Center"
+                                            Foreground="MediumPurple"
+                                            Text="O aplikaciji" />
                                     </StackPanel>
                                 </ListViewItem>
 
@@ -311,127 +472,535 @@
                     </StackPanel>
 
                     <StackPanel x:Name="InfoAndEditingPanel" Style="{StaticResource MenuClosed}">
-                        <!--OBJECT INFO DISPLAY PANEL-->
-                        <StackPanel x:Name="NormalPanel" VerticalAlignment="Top"
+                        <!--  CONTAINER PANEL WITH MENU BUTTON  -->
+                        <StackPanel
+                            x:Name="NormalPanel"
+                            VerticalAlignment="Top"
                             Style="{StaticResource NormalMode}">
 
-                        <Grid>
-                            <Grid.RowDefinitions>
-                                <RowDefinition Height="*" />
-                                <RowDefinition Height="*" />
-                            </Grid.RowDefinitions>
-
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="*" />
-                                <ColumnDefinition Width="3*" />
-                                <ColumnDefinition Width="*" />
-                            </Grid.ColumnDefinitions>
-
-                            <!--OBJECT TYPE-->
-                            <TextBlock Text="{Binding DisplayMapObject.MapObjectType.ObjectTypeFullName}" 
-                                Grid.Row="0"
-                                Grid.Column="1"
-                                FontSize="26" 
-                                TextWrapping="Wrap"
-                                HorizontalAlignment="Center"
-                                VerticalAlignment="Center">
-                            </TextBlock>
-
-
-                            <Button x:Name="OpenMenuButton"  Style="{StaticResource EditingModeMenuButton}" HorizontalAlignment="Right" VerticalAlignment="Top" Grid.Row="0"  Grid.Column="2" Height="Auto" Width="Auto" Background="{x:Null}" BorderBrush="{x:Null}" Click="OpenMenuButton_Click">
-                                <materialDesign:PackIcon Kind="Menu" Width="50" Height="50" HorizontalAlignment="Center" VerticalAlignment="Center" Foreground="MediumPurple"/>
+                            <Button
+                                x:Name="OpenMenuButton"
+                                Width="Auto"
+                                Height="Auto"
+                                Margin="0,0,0,0"
+                                HorizontalAlignment="Right"
+                                VerticalAlignment="Top"
+                                Background="{x:Null}"
+                                BorderBrush="{x:Null}"
+                                Click="OpenMenuButton_Click"
+                                Style="{StaticResource EditingModeMenuButton}">
+                                <materialDesign:PackIcon
+                                    Width="50"
+                                    Height="50"
+                                    HorizontalAlignment="Center"
+                                    VerticalAlignment="Center"
+                                    Foreground="MediumPurple"
+                                    Kind="Menu" />
                             </Button>
 
-                            <!--OBJECT ID-->
-                            <TextBlock Text="{Binding DisplayMapObject.Id}" 
-                                Grid.Row="1"
-                                Grid.Column="1"
-                                FontSize="20"
-                                Margin="0 -5 0 0"
+                            <!--  OBJECT INFO, EQUIPMENT AND MEDICINE CONTAINER PANEL  -->
+                            <StackPanel Style="{StaticResource ObjectInfoPanelSelectedFromMenu}">
+                                <StackPanel x:Name="ObjecInfoEquipmenMedicinePanel" Style="{StaticResource NoSelectionObjectInfoPanel}">
+                                    <!--  OBJECT INFO DISPLAY PANEL  -->
+                                    <StackPanel x:Name="ObjectInfoPanel">
+                                        <!--  OBJECT TYPE  -->
+                                        <TextBlock
+                                            HorizontalAlignment="Center"
+                                            VerticalAlignment="Center"
+                                            FontSize="26"
+                                            Text="{Binding DisplayMapObject.MapObjectType.ObjectTypeFullName}"
+                                            TextWrapping="Wrap" />
+
+
+                                        <!--  OBJECT ID  -->
+                                        <TextBlock
+                                            Margin="0,5,0,0"
+                                            HorizontalAlignment="Center"
+                                            VerticalAlignment="Top"
+                                            FontSize="20"
+                                            Text="{Binding DisplayMapObject.Id}" />
+
+
+                                        <!--  OBJECT DESCRIPTION  -->
+                                        <TextBlock
+                                            x:Name="Prop"
+                                            Margin="0,20,0,0"
+                                            FontSize="16"
+                                            Text="{Binding DisplayMapObject.Description}"
+                                            TextWrapping="Wrap" />
+
+                                        <!--  OBJECT EDITING BUTTON  -->
+                                        <Button
+                                            x:Name="EditObjectButton"
+                                            Height="Auto"
+                                            Margin="0,30,0,0"
+                                            Padding="5"
+                                            Background="#7D80DA"
+                                            BorderBrush="{x:Null}"
+                                            Click="Edit_Display_Information"
+                                            FontSize="18">
+                                            <StackPanel
+                                                HorizontalAlignment="Center"
+                                                VerticalAlignment="Center"
+                                                Orientation="Horizontal">
+                                                <materialDesign:PackIcon
+                                                    Width="25"
+                                                    Height="25"
+                                                    HorizontalAlignment="Left"
+                                                    VerticalAlignment="Center"
+                                                    Foreground="White"
+                                                    Kind="Edit" />
+                                                <TextBlock
+                                                    Margin="5"
+                                                    HorizontalAlignment="Right"
+                                                    VerticalAlignment="Center"
+                                                    Foreground="White"
+                                                    Text="Izmeni" />
+                                            </StackPanel>
+                                        </Button>
+                                    </StackPanel>
+
+                                    <Separator Margin="0,20,0,20" Background="MediumPurple" />
+
+                                    <!--  OBJECT EQUIPMENT AND MEDICINE PANEL  -->
+                                    <StackPanel x:Name="ObjectEquipmentAndMedicinePanel">
+                                        <!--  OBJECT EQUIPMENT GRID  -->
+                                        <Grid x:Name="ObjectEquipmentGrid">
+                                            <Grid.RowDefinitions>
+                                                <RowDefinition Height="1*" />
+                                                <RowDefinition Height="6*" />
+                                            </Grid.RowDefinitions>
+
+                                            <TextBlock
+                                                Grid.Row="0"
+                                                Margin="0,0,0,10"
+                                                FontSize="18"
+                                                FontWeight="Normal"
+                                                Foreground="Black">
+                                                Oprema u objektu:
+                                            </TextBlock>
+
+                                            <!--  OBJECT EQUIPMENT TABLE  -->
+                                            <DataGrid
+                                                x:Name="ObjectEquipmentDataGrid"
+                                                Grid.Row="1"
+                                                Margin="0,0,0,0"
+                                                AutoGenerateColumns="False"
+                                                CanUserAddRows="False"
+                                                CanUserDeleteRows="False"
+                                                CanUserReorderColumns="False"
+                                                CanUserResizeColumns="False"
+                                                CanUserResizeRows="False"
+                                                ColumnHeaderHeight="30"
+                                                FontFamily="Roboto"
+                                                HeadersVisibility="Column"
+                                                HorizontalGridLinesBrush="#C5E3BF"
+                                                IsReadOnly="True"
+                                                ItemsSource="{Binding DisplayMapObject}"
+                                                SelectionMode="Single"
+                                                VerticalGridLinesBrush="Transparent"
+                                                VerticalScrollBarVisibility="Visible">
+
+                                                <!--  Styling DataGrid  -->
+                                                <DataGrid.Resources>
+                                                    <Style TargetType="DataGridColumnHeader">
+                                                        <Setter Property="Background" Value="MediumPurple" />
+                                                        <Setter Property="Foreground" Value="White" />
+                                                        <Setter Property="FontFamily" Value="Roboto" />
+                                                        <Setter Property="FontSize" Value="16" />
+                                                        <Setter Property="HorizontalContentAlignment" Value="Center" />
+                                                        <Setter Property="VerticalContentAlignment" Value="Center" />
+                                                    </Style>
+
+                                                    <!--  Styling DataGrid  Rows  -->
+                                                    <Style TargetType="DataGridRow">
+                                                        <Setter Property="Height" Value="40" />
+                                                        <Setter Property="FontSize" Value="16" />
+
+                                                        <Style.Resources>
+                                                            <SolidColorBrush x:Key="{x:Static SystemColors.HighlightBrushKey}" Color="LightBlue" />
+                                                            <SolidColorBrush x:Key="{x:Static SystemColors.ControlBrushKey}" Color="Green" />
+                                                            <SolidColorBrush x:Key="{x:Static SystemColors.HighlightTextBrushKey}" Color="Black" />
+                                                            <SolidColorBrush x:Key="{x:Static SystemColors.ControlTextBrushKey}" Color="Black" />
+                                                        </Style.Resources>
+                                                    </Style>
+                                                </DataGrid.Resources>
+
+                                                <!--  Styling DataGrid Cells  -->
+                                                <DataGrid.CellStyle>
+                                                    <Style TargetType="DataGridCell">
+                                                        <Setter Property="BorderThickness" Value="0" />
+                                                        <Setter Property="FocusVisualStyle" Value="{x:Null}" />
+                                                        <Style.Resources>
+                                                            <Style TargetType="ContentPresenter">
+                                                                <Setter Property="HorizontalAlignment" Value="Center" />
+                                                                <Setter Property="VerticalAlignment" Value="Center" />
+                                                            </Style>
+                                                        </Style.Resources>
+                                                    </Style>
+                                                </DataGrid.CellStyle>
+
+
+                                                <!--  Table Column Headers Names and Binding  -->
+                                                <DataGrid.Columns>
+                                                    <DataGridTextColumn
+                                                        Width="3*"
+                                                        Binding="{Binding DisplayMapObject.Id}"
+                                                        Header="Naziv opreme" />
+                                                    <DataGridTextColumn
+                                                        Width="1*"
+                                                        Binding="{Binding DisplayMapObject.MapObjectType.ObjectTypeFullName}"
+                                                        Header="Količina" />
+                                                </DataGrid.Columns>
+                                            </DataGrid>
+                                        </Grid>
+
+
+                                        <Separator Margin="0,20,0,20" Background="MediumPurple" />
+
+                                        <!--  OBJECT MEDICINE GRID  -->
+                                        <Grid x:Name="ObjectMedicineGrid">
+                                            <Grid.RowDefinitions>
+                                                <RowDefinition Height="1*" />
+                                                <RowDefinition Height="6*" />
+                                            </Grid.RowDefinitions>
+
+                                            <TextBlock
+                                                Grid.Row="0"
+                                                Margin="0,0,0,10"
+                                                FontSize="18"
+                                                FontWeight="Normal"
+                                                Foreground="Black">
+                                                Lekovi u objektu:
+                                            </TextBlock>
+
+                                            <!--  OBJECT MEDICINE TABLE  -->
+                                            <DataGrid
+                                                x:Name="ObjectMedicineDataGrid"
+                                                Grid.Row="1"
+                                                Margin="0,0,0,0"
+                                                AutoGenerateColumns="False"
+                                                CanUserAddRows="False"
+                                                CanUserDeleteRows="False"
+                                                CanUserReorderColumns="False"
+                                                CanUserResizeColumns="False"
+                                                CanUserResizeRows="False"
+                                                ColumnHeaderHeight="30"
+                                                FontFamily="Roboto"
+                                                HeadersVisibility="Column"
+                                                HorizontalGridLinesBrush="#C5E3BF"
+                                                IsReadOnly="True"
+                                                ItemsSource="{Binding DisplayMapObject}"
+                                                SelectionMode="Single"
+                                                VerticalGridLinesBrush="Transparent"
+                                                VerticalScrollBarVisibility="Visible">
+
+                                                <!--  Styling DataGrid  -->
+                                                <DataGrid.Resources>
+                                                    <Style TargetType="DataGridColumnHeader">
+                                                        <Setter Property="Background" Value="MediumPurple" />
+                                                        <Setter Property="Foreground" Value="White" />
+                                                        <Setter Property="FontFamily" Value="Roboto" />
+                                                        <Setter Property="FontSize" Value="16" />
+                                                        <Setter Property="HorizontalContentAlignment" Value="Center" />
+                                                        <Setter Property="VerticalContentAlignment" Value="Center" />
+                                                    </Style>
+
+                                                    <!--  Styling DataGrid  Rows  -->
+                                                    <Style TargetType="DataGridRow">
+                                                        <Setter Property="Height" Value="40" />
+                                                        <Setter Property="FontSize" Value="16" />
+
+                                                        <Style.Resources>
+                                                            <SolidColorBrush x:Key="{x:Static SystemColors.HighlightBrushKey}" Color="LightBlue" />
+                                                            <SolidColorBrush x:Key="{x:Static SystemColors.ControlBrushKey}" Color="Green" />
+                                                            <SolidColorBrush x:Key="{x:Static SystemColors.HighlightTextBrushKey}" Color="Black" />
+                                                            <SolidColorBrush x:Key="{x:Static SystemColors.ControlTextBrushKey}" Color="Black" />
+                                                        </Style.Resources>
+                                                    </Style>
+                                                </DataGrid.Resources>
+
+                                                <!--  Styling DataGrid Cells  -->
+                                                <DataGrid.CellStyle>
+                                                    <Style TargetType="DataGridCell">
+                                                        <Setter Property="BorderThickness" Value="0" />
+                                                        <Setter Property="FocusVisualStyle" Value="{x:Null}" />
+                                                        <Style.Resources>
+                                                            <Style TargetType="ContentPresenter">
+                                                                <Setter Property="HorizontalAlignment" Value="Center" />
+                                                                <Setter Property="VerticalAlignment" Value="Center" />
+                                                            </Style>
+                                                        </Style.Resources>
+                                                    </Style>
+                                                </DataGrid.CellStyle>
+
+
+                                                <!--  Table Column Headers Names and Binding  -->
+                                                <DataGrid.Columns>
+                                                    <DataGridTextColumn Width="3*" Header="Naziv leka" />
+                                                    <!--  Binding="{Binding DisplayMapObject.Id}"  -->
+                                                    <DataGridTextColumn Width="1*" Header="Količina" />
+                                                    <!--  Binding="{Binding DisplayMapObject.MapObjectType.ObjectTypeFullName}"  -->
+                                                </DataGrid.Columns>
+                                            </DataGrid>
+                                        </Grid>
+                                    </StackPanel>
+                                </StackPanel>
+                            </StackPanel>
+
+                            <!--  SEARCH OBJECTS PANEL  -->
+                            <StackPanel x:Name="SearchObjectsPanel" Style="{StaticResource SearchObjectsPanelSelectedFromMenu}">
+                                <StackPanel>
+                                    <TextBlock
+                                        HorizontalAlignment="Left"
+                                        VerticalAlignment="Center"
+                                        FontSize="26"
+                                        Text="Pretraga objekata: "
+                                        TextWrapping="Wrap" />
+
+                                    <ComboBox
+                                        Name="SearchObjectTypeComboBox"
+                                        Margin="0,20,0,0"
+                                        materialDesign:HintAssist.Hint="Izaberite tip objekta."
+                                        FontSize="16">
+                                        <!--  ItemsSource="{Binding DisplayMapObject.MapObjectType.AllMapObjectTypesAvailableToChange}">  -->
+                                        <ComboBox.ItemTemplate>
+                                            <DataTemplate>
+                                                <!-- <TextBlock Text="{Binding Path=ObjectTypeFullName}" /> -->
+                                            </DataTemplate>
+                                        </ComboBox.ItemTemplate>
+                                    </ComboBox>
+
+
+                                    <!--  SEARCH OBJECTS BUTTON  -->
+                                    <Button
+                                        x:Name="SearchObjectsButton"
+                                        Height="Auto"
+                                        Margin="0,30,0,0"
+                                        Padding="5"
+                                        Background="#7D80DA"
+                                        BorderBrush="{x:Null}"
+                                        FontSize="18">
+                                        <StackPanel
+                                            HorizontalAlignment="Center"
+                                            VerticalAlignment="Center"
+                                            Orientation="Horizontal">
+                                            <materialDesign:PackIcon
+                                                Width="25"
+                                                Height="25"
+                                                HorizontalAlignment="Left"
+                                                VerticalAlignment="Center"
+                                                Foreground="White"
+                                                Kind="MapSearchOutline" />
+                                            <TextBlock
+                                                Margin="5"
+                                                HorizontalAlignment="Right"
+                                                VerticalAlignment="Center"
+                                                Foreground="White"
+                                                Text="Pretraži objekte" />
+                                        </StackPanel>
+                                    </Button>
+
+                                    <Separator Margin="0,20,0,20" Background="MediumPurple" />
+                                </StackPanel>
+                            </StackPanel>
+
+                            <!--  SEARCH EQUIPMENT AND MEDICINE PANEL  -->
+                            <StackPanel x:Name="SearchEquipmentAndMedicinePanel" Style="{StaticResource SearchEquipmentAndMedicinePanelSelectedFromMenu}">
+                                <StackPanel>
+                                    <TextBlock
+                                        HorizontalAlignment="Left"
+                                        VerticalAlignment="Center"
+                                        FontSize="26"
+                                        Text="Pretraga opreme i lekova: "
+                                        TextWrapping="Wrap" />
+
+                                    <TextBox
+                                        Margin="0,20,0,0"
+                                        materialDesign:HintAssist.Hint="Unesite naziv opreme ili leka."
+                                        FontSize="16"
+                                        TextWrapping="Wrap" />
+
+
+                                    <!--  SEARCH EQUIPMENT AND MEDICINE BUTTON  -->
+                                    <Button
+                                        x:Name="SearchEquimentAndMedicineButton"
+                                        Height="Auto"
+                                        Margin="0,30,0,0"
+                                        Padding="5"
+                                        Background="#7D80DA"
+                                        BorderBrush="{x:Null}"
+                                        FontSize="18">
+                                        <StackPanel
+                                            HorizontalAlignment="Center"
+                                            VerticalAlignment="Center"
+                                            Orientation="Horizontal">
+                                            <materialDesign:PackIcon
+                                                Width="25"
+                                                Height="25"
+                                                HorizontalAlignment="Left"
+                                                VerticalAlignment="Center"
+                                                Foreground="White"
+                                                Kind="SearchPlus" />
+                                            <TextBlock
+                                                Margin="5"
+                                                HorizontalAlignment="Right"
+                                                VerticalAlignment="Center"
+                                                Foreground="White"
+                                                Text="Pretraži opremu i lekove" />
+                                        </StackPanel>
+                                    </Button>
+
+                                    <Separator Margin="0,20,0,20" Background="MediumPurple" />
+                                </StackPanel>
+                            </StackPanel>
+
+                            <!--  SEARCH APPOINTMENTS PANEL  -->
+                            <StackPanel x:Name="SearchAppointmentsPanel" Style="{StaticResource SearchAppointmentsPanelSelectedFromMenu}">
+                                <StackPanel>
+                                    <TextBlock
+                                        HorizontalAlignment="Left"
+                                        VerticalAlignment="Center"
+                                        FontSize="26"
+                                        Text="Pretraga termina: "
+                                        TextWrapping="Wrap" />
+
+                                    <ComboBox
+                                        Name="AppointmentSearchDoctorComboBox"
+                                        Margin="0,20,0,0"
+                                        materialDesign:HintAssist.Hint="Izaberite lekara opšte prakse."
+                                        FontSize="16">
+                                        <!--  ItemsSource="{Binding DisplayMapObject.MapObjectType.AllMapObjectTypesAvailableToChange}">  -->
+                                        <ComboBox.ItemTemplate>
+                                            <DataTemplate>
+                                                <!-- <TextBlock Text="{Binding Path=ObjectTypeFullName}" /> -->
+                                            </DataTemplate>
+                                        </ComboBox.ItemTemplate>
+                                    </ComboBox>
+
+
+                                    <!--  SEARCH EQUIPMENT AND MEDICINE BUTTON  -->
+                                    <Button
+                                        x:Name="SearchAppointmentsButton"
+                                        Height="Auto"
+                                        Margin="0,30,0,0"
+                                        Padding="5"
+                                        Background="#7D80DA"
+                                        BorderBrush="{x:Null}"
+                                        FontSize="18">
+                                        <StackPanel
+                                            HorizontalAlignment="Center"
+                                            VerticalAlignment="Center"
+                                            Orientation="Horizontal">
+                                            <materialDesign:PackIcon
+                                                Width="25"
+                                                Height="25"
+                                                HorizontalAlignment="Left"
+                                                VerticalAlignment="Center"
+                                                Foreground="White"
+                                                Kind="CalendarClock" />
+                                            <TextBlock
+                                                Margin="5"
+                                                HorizontalAlignment="Right"
+                                                VerticalAlignment="Center"
+                                                Foreground="White"
+                                                Text="Pretraži termine" />
+                                        </StackPanel>
+                                    </Button>
+
+                                    <Separator Margin="0,20,0,20" Background="MediumPurple" />
+                                </StackPanel>
+                            </StackPanel>
+
+
+                        </StackPanel>
+
+                        <!--  OBJECT INFO EDITING INPUT PANEL  -->
+                        <StackPanel x:Name="EditPanel" Style="{StaticResource EditingMode}">
+                            <ComboBox
+                                Name="ObjectTypeChooserComboBox"
+                                materialDesign:HintAssist.Hint="Izaberite tip objekta."
+                                FontSize="16"
+                                ItemsSource="{Binding DisplayMapObject.MapObjectType.AllMapObjectTypesAvailableToChange}">
+                                <ComboBox.ItemTemplate>
+                                    <DataTemplate>
+                                        <TextBlock Text="{Binding Path=ObjectTypeFullName}" />
+                                    </DataTemplate>
+                                </ComboBox.ItemTemplate>
+                            </ComboBox>
+
+                            <TextBox
+                                Margin="0,5,0,0"
                                 HorizontalAlignment="Center"
-                                VerticalAlignment="Top"/>
-                        </Grid>
+                                FontSize="20"
+                                IsReadOnly="True"
+                                Text="{Binding DisplayMapObject.Id}" />
 
-                        <!--OBJECT DESCRIPTION-->
-                        <TextBlock x:Name="Prop" Text="{Binding DisplayMapObject.Description}" 
-                           TextWrapping="Wrap"
-                           FontSize="16" 
-                           Margin="0 10 0 0">
-                        </TextBlock>
+                            <TextBox
+                                Margin="0,10,0,0"
+                                materialDesign:HintAssist.Hint="Unesite deskripciju objekta."
+                                FontSize="16"
+                                Text="{Binding DisplayMapObject.Description}"
+                                TextWrapping="Wrap" />
 
-                        <!--OBJECT EDITING BUTTON-->
-                        <Button
-                            x:Name="EditObjectButton"
-                            Height="Auto"
-                            Padding="5"
-                            FontSize="18"
-                            Margin="0 10"
-                            Background="#7D80DA"
-                            BorderBrush="{x:Null}"
-                            Click="Edit_Display_Information">
-                            <StackPanel Orientation="Horizontal" VerticalAlignment="Center" HorizontalAlignment="Center">
-                                <materialDesign:PackIcon Kind="Edit" Foreground="White" Width="25" Height="25"  HorizontalAlignment="Left" VerticalAlignment="Center"/>
-                                <TextBlock Text="Izmeni" Foreground="White" HorizontalAlignment="Right" VerticalAlignment="Center" Margin="5"/>
-                            </StackPanel>
-                        </Button>
+                            <Button
+                                x:Name="SaveButton"
+                                Height="Auto"
+                                Margin="0,15,0,0"
+                                Padding="5"
+                                Background="#7D80DA"
+                                BorderBrush="{x:Null}"
+                                Click="Change_Display_Information"
+                                FontSize="18">
+                                <StackPanel
+                                    HorizontalAlignment="Center"
+                                    VerticalAlignment="Center"
+                                    Orientation="Horizontal">
+                                    <materialDesign:PackIcon
+                                        Width="25"
+                                        Height="25"
+                                        HorizontalAlignment="Left"
+                                        VerticalAlignment="Center"
+                                        Foreground="White"
+                                        Kind="ContentSave" />
+                                    <TextBlock
+                                        Margin="5"
+                                        HorizontalAlignment="Right"
+                                        VerticalAlignment="Center"
+                                        Foreground="White"
+                                        Text="Sačuvaj" />
+                                </StackPanel>
+                            </Button>
 
-                    </StackPanel>
+                            <Button
+                                Height="Auto"
+                                Margin="0,10,0,0"
+                                Padding="5"
+                                Background="#F2404C"
+                                BorderBrush="{x:Null}"
+                                Click="Cancel_Editing_Mode"
+                                FontSize="18">
+                                <StackPanel
+                                    HorizontalAlignment="Center"
+                                    VerticalAlignment="Center"
+                                    Orientation="Horizontal">
+                                    <materialDesign:PackIcon
+                                        Width="25"
+                                        Height="25"
+                                        HorizontalAlignment="Left"
+                                        VerticalAlignment="Center"
+                                        Foreground="White"
+                                        Kind="CloseBox" />
+                                    <TextBlock
+                                        Margin="5"
+                                        HorizontalAlignment="Right"
+                                        VerticalAlignment="Center"
+                                        Foreground="White"
+                                        Text="Otkaži   " />
+                                </StackPanel>
+                            </Button>
 
-                    <!--OBJECT INFO EDITING INPUT PANEL-->
-                    <StackPanel x:Name="EditPanel"
-                            Style="{StaticResource EditingMode}">
-                        <ComboBox Name="ObjectTypeChooserComboBox" ItemsSource="{Binding DisplayMapObject.MapObjectType.AllMapObjectTypesAvailableToChange}"
-                              FontSize="16"
-                              materialDesign:HintAssist.Hint="Izaberite tip objekta.">
-                            <ComboBox.ItemTemplate>
-                                <DataTemplate>
-                                    <TextBlock Text="{Binding Path=ObjectTypeFullName}"></TextBlock>
-                                </DataTemplate>
-                            </ComboBox.ItemTemplate>
-                        </ComboBox>
-
-                        <TextBox IsReadOnly="True" Text="{Binding DisplayMapObject.Id}" 
-                           FontSize="20"
-                           Margin="0 5 0 0"
-                           HorizontalAlignment="Center"/>
-
-                        <TextBox Text="{Binding DisplayMapObject.Description}" 
-                           TextWrapping="Wrap"
-                           FontSize="16" 
-                           Margin="0 10 0 0"
-                           materialDesign:HintAssist.Hint="Unesite deskripciju objekta.">
-                        </TextBox>
-
-                        <Button 
-                            x:Name="SaveButton"
-                            Height="Auto"
-                            Padding="5"
-                            FontSize="18"
-                            Margin="0 15 0 0"
-                            Background="#7D80DA"
-                            BorderBrush="{x:Null}"
-                            Click="Change_Display_Information">
-                            <StackPanel Orientation="Horizontal" VerticalAlignment="Center" HorizontalAlignment="Center">
-                                <materialDesign:PackIcon Kind="ContentSave" Foreground="White" Width="25" Height="25"  HorizontalAlignment="Left" VerticalAlignment="Center"/>
-                                <TextBlock Text="Sačuvaj" Foreground="White" HorizontalAlignment="Right" VerticalAlignment="Center" Margin="5"/>
-                            </StackPanel>
-                        </Button>
-
-                        <Button 
-                            Height="Auto"
-                            Padding="5"
-                            FontSize="18"
-                            Margin="0 10 0 0"
-                            Background="#F2404C"
-                            BorderBrush="{x:Null}"
-                            Click="Cancel_Editing_Mode">
-                            <StackPanel Orientation="Horizontal" VerticalAlignment="Center" HorizontalAlignment="Center">
-                                <materialDesign:PackIcon Kind="CloseBox" Foreground="White" Width="25" Height="25"  HorizontalAlignment="Left" VerticalAlignment="Center"/>
-                                <TextBlock Text="Otkaži   " Foreground="White" HorizontalAlignment="Right" VerticalAlignment="Center" Margin="5"/>
-                            </StackPanel>
-                        </Button>
-
-                       </StackPanel>
+                        </StackPanel>
                     </StackPanel>
                 </StackPanel>
             </StackPanel>

--- a/HealthcareSystem/GraphicalEditor/MainWindow.xaml.cs
+++ b/HealthcareSystem/GraphicalEditor/MainWindow.xaml.cs
@@ -61,6 +61,17 @@ namespace GraphicalEditor
             }
         }
 
+        private int _selectedMenuOptionIndex = 0;
+        public int SelectedMenuOptionIndex
+        {
+            get { return _selectedMenuOptionIndex; }
+            set
+            {
+                _selectedMenuOptionIndex = value;
+                OnPropertyChanged("SelectedMenuOptionIndex");
+            }
+        }
+
         public event PropertyChangedEventHandler PropertyChanged;
 
         protected void OnPropertyChanged(string propertyName = null)
@@ -177,7 +188,7 @@ namespace GraphicalEditor
 
         public void ChangeEditButtonVisibility()
         {
-            EditObjectButton.Visibility = Visibility.Hidden;
+            EditObjectButton.Visibility = Visibility.Collapsed;
             EditMode = false;
 
             if (!String.IsNullOrEmpty(_currentUserRole) && _currentUserRole.Equals("Manager") && (_selectedMapObject != null))
@@ -400,19 +411,24 @@ namespace GraphicalEditor
 
         private void ListViewExtendMenu_SelectionChanged(object sender, SelectionChangedEventArgs e)
         {
-            int selectedMenuOptionIndex = ListViewExtendMenu.SelectedIndex;
+            SelectedMenuOptionIndex = ListViewExtendMenu.SelectedIndex;
 
-            switch (selectedMenuOptionIndex)
+            switch (SelectedMenuOptionIndex)
             {
                 case 0:
+                    IsMenuOpened = false;
                     break;
                 case 1:
+                    IsMenuOpened = false;
                     break;
                 case 2:
+                    IsMenuOpened = false;
                     break;
                 case 3:
+                    IsMenuOpened = false;
                     break;
                 case 4:
+                    IsMenuOpened = false;
                     break;
             }
         }


### PR DESCRIPTION
This branch contains mostly XAML code for menu options and different application functionalities.

- Switching menu options and panels depending on selected menu option
- Panels for selected object's equipment and medicine overview
- Panel for searching map objects
- Panel for searching equipment and medicine
- Panel for searching terms
- Panel for searching map objects

Data grids and some of the other controls don't have any binding yet, but we will bind them during further implementation.
This is just to make general switching logic and layout so we can implement these functionalities.