### PR TITLE
feat[g13]: Patient restriction - Patient cant see information about objects that are only for staff

### DIFF
--- a/HealthcareSystem/GraphicalEditor/MainWindow.xaml.cs
+++ b/HealthcareSystem/GraphicalEditor/MainWindow.xaml.cs
@@ -146,6 +146,26 @@ namespace GraphicalEditor
             saveMap();
             LoadInitialMapOnCanvas();
             ChangeEditButtonVisibility();
+
+            RestrictUsersAccessBasedOnRole();
+        }
+
+        private void RestrictUsersAccessBasedOnRole()
+        {
+
+            if (!String.IsNullOrEmpty(_currentUserRole))
+            {
+                if (_currentUserRole.Equals("Patient"))
+                {
+                    ObjectEquipmentAndMedicinePanel.Visibility = Visibility.Collapsed;
+                    SearchEquipmentAndMedicineMenuItem.Visibility = Visibility.Collapsed;
+                }
+
+                if (!_currentUserRole.Equals("Manager"))
+                {
+                    EditObjectButton.Visibility = Visibility.Collapsed;
+                }
+            }
         }
 
 


### PR DESCRIPTION
On this branch I have implemented Patient Restriction:
- Patient can't see information that is for staff only - Equipment and Medicine overview for each object
- Patient can't search for equipment and medicine because these are confidential information that can only be seen by staff of the hospital

This is the last feature/user story from Sprint 1 and only one that we haven't implemented during Sprint 1.  