### PR TITLE
Chore: Switched to Linux based Docker images

### DIFF
--- a/HealthcareSystem/GraphicalEditorServer/Dockerfile
+++ b/HealthcareSystem/GraphicalEditorServer/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/aspnet:3.1
+FROM mcr.microsoft.com/dotnet/core/aspnet:3.1-buster-slim
 WORKDIR /app
 COPY . .
 EXPOSE 80

--- a/HealthcareSystem/IntegrationAdapters/Dockerfile
+++ b/HealthcareSystem/IntegrationAdapters/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/aspnet:3.1
+FROM mcr.microsoft.com/dotnet/core/aspnet:3.1-buster-slim
 WORKDIR /app
 COPY . .
 EXPOSE 80

--- a/HealthcareSystem/PatientWebApp/Dockerfile
+++ b/HealthcareSystem/PatientWebApp/Dockerfile
@@ -1,4 +1,4 @@
-FROM mcr.microsoft.com/dotnet/core/aspnet:3.1
+FROM mcr.microsoft.com/dotnet/core/aspnet:3.1-buster-slim
 WORKDIR /app
 COPY . .
 EXPOSE 80

--- a/pipelines/adapters-ci.yml
+++ b/pipelines/adapters-ci.yml
@@ -1,9 +1,6 @@
 trigger:
 - develop
 
-pool:
-  vmImage: 'windows-latest'
-
 variables:
   paths: "**/IntegrationAdapters/* **/IntegrationAdaptersTests/* **/Backend/*"
   project: 'HealthcareSystem/IntegrationAdapters/IntegrationAdapters.csproj'
@@ -18,6 +15,8 @@ variables:
 
 jobs:
 - job: Check
+  pool:
+    vmImage: 'ubuntu-18.04'
   steps:
   - task: PowerShell@2
     displayName: 'Check if build is needed'
@@ -66,6 +65,8 @@ jobs:
 - job: Build
   dependsOn: Check
   condition: eq(dependencies.Check.outputs['CheckChangedFiles.shouldBuild'], 'Yes')
+  pool:
+    vmImage: 'windows-latest'
   steps:
     - task: DotNetCoreInstaller@0
       displayName: 'Use .NET Core SDK 2.2.103 for SonarCloud'
@@ -128,6 +129,12 @@ jobs:
         packageType: 'sdk'
         version: '3.1.x'
 
+- job: Docker
+  dependsOn: Check
+  condition: eq(dependencies.Check.outputs['CheckChangedFiles.shouldBuild'], 'Yes')
+  pool:
+    vmImage: 'ubuntu-18.04'
+  steps:
     - task: Bash@3
       displayName: 'Prepare context for Docker'
       inputs:
@@ -148,4 +155,3 @@ jobs:
         tags: |
           $(Build.BuildId)
           latest
-

--- a/pipelines/editor-server-ci.yml
+++ b/pipelines/editor-server-ci.yml
@@ -1,9 +1,6 @@
 trigger:
 - develop
 
-pool:
-  vmImage: 'windows-latest'
-
 variables:
   paths: "**/GraphicalEditorServer/* **/GraphicalEditorServerTests/* **/Backend/*"
   project: 'HealthcareSystem/GraphicalEditorServer/GraphicalEditorServer.csproj'
@@ -18,6 +15,8 @@ variables:
 
 jobs:
 - job: Check
+  pool:
+    vmImage: 'ubuntu-18.04'
   steps:
   - task: PowerShell@2
     displayName: 'Check if build is needed'
@@ -66,6 +65,8 @@ jobs:
 - job: Build
   dependsOn: Check
   condition: eq(dependencies.Check.outputs['CheckChangedFiles.shouldBuild'], 'Yes')
+  pool:
+    vmImage: 'windows-latest'
   steps:
     - task: DotNetCoreInstaller@0
       displayName: 'Use .NET Core SDK 2.2.103 for SonarCloud'
@@ -128,6 +129,12 @@ jobs:
         packageType: 'sdk'
         version: '3.1.x'
 
+- job: Docker
+  dependsOn: Check
+  condition: eq(dependencies.Check.outputs['CheckChangedFiles.shouldBuild'], 'Yes')
+  pool:
+    vmImage: 'ubuntu-18.04'
+  steps:
     - task: Bash@3
       displayName: 'Prepare context for Docker'
       inputs:

--- a/pipelines/web-ci.yml
+++ b/pipelines/web-ci.yml
@@ -1,9 +1,6 @@
 trigger:
 - develop
 
-pool:
-  vmImage: 'windows-latest'
-
 variables:
   paths: "**/PatientWebApp/* **/PatientWebAppTests/* **/Backend/*"
   project: 'HealthcareSystem/PatientWebApp/PatientWebApp.csproj'
@@ -18,6 +15,8 @@ variables:
 
 jobs:
 - job: Check
+  pool:
+    vmImage: 'ubuntu-18.04'
   steps:
   - task: PowerShell@2
     displayName: 'Check if build is needed'
@@ -66,6 +65,8 @@ jobs:
 - job: Build
   dependsOn: Check
   condition: eq(dependencies.Check.outputs['CheckChangedFiles.shouldBuild'], 'Yes')
+  pool:
+    vmImage: 'windows-latest'
   steps:
     - task: DotNetCoreInstaller@0
       displayName: 'Use .NET Core SDK 2.2.103 for SonarCloud'
@@ -128,6 +129,12 @@ jobs:
         packageType: 'sdk'
         version: '3.1.x'
 
+- job: Docker
+  dependsOn: Check
+  condition: eq(dependencies.Check.outputs['CheckChangedFiles.shouldBuild'], 'Yes')
+  pool:
+    vmImage: 'ubuntu-18.04'
+  steps:
     - task: Bash@3
       displayName: 'Prepare context for Docker'
       inputs:
@@ -148,3 +155,4 @@ jobs:
         tags: |
           $(Build.BuildId)
           latest
+


### PR DESCRIPTION
- The Dockerfiles for PatientWebApp, IntegrationAdapters, and GraphicalEditorServer were switched to Linux based images in order to be deployable to Heroku.
- The CI pipelines were edited to separate building and pushing Docker images into a separate job, because building Linux based images requires a Linux agent, while collecting code coverage in the build step required a Windows agent.