### PR TITLE
gui[g-all]: GUI Panels Redesign, Switched to Grids, Added Styles and Transitions

### DIFF
--- a/HealthcareSystemFrontends/DoctorFrontend/App.xaml
+++ b/HealthcareSystemFrontends/DoctorFrontend/App.xaml
@@ -1,8 +1,9 @@
-﻿<Application x:Class="WpfApp1.App"
-             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:local="clr-namespace:WpfApp1"
-             StartupUri="Wizard/Window1.xaml">
+﻿<Application
+    x:Class="WpfApp1.App"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="clr-namespace:WpfApp1"
+    StartupUri="Wizard/Window1.xaml">
     <Application.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
@@ -14,13 +15,116 @@
 
 
             <Style TargetType="Button">
-                <Setter Property="Padding" Value="0"/>
+                <Setter Property="Padding" Value="0" />
             </Style>
 
             <Style TargetType="MenuItem">
-                <Setter Property="Padding" Value="10 2 10 0"/>
+                <Setter Property="Padding" Value="10,2,10,0" />
             </Style>
-            
+
+
+
+            <!--  GRAPHICAL EDITOR STYLES  -->
+
+            <!--  SIDE PANEL DATA GRID STYLE  -->
+            <!--  DataGrid  -->
+            <Style
+                x:Key="SidePanelDataGrid"
+                BasedOn="{StaticResource MaterialDesignDataGrid}"
+                TargetType="DataGrid">
+                <Setter Property="AutoGenerateColumns" Value="False" />
+                <Setter Property="CanUserAddRows" Value="False" />
+                <Setter Property="CanUserDeleteRows" Value="False" />
+                <Setter Property="CanUserReorderColumns" Value="False" />
+                <Setter Property="CanUserResizeColumns" Value="False" />
+                <Setter Property="CanUserResizeRows" Value="False" />
+                <Setter Property="ColumnHeaderHeight" Value="30" />
+                <Setter Property="HeadersVisibility" Value="Column" />
+                <Setter Property="IsReadOnly" Value="True" />
+                <Setter Property="SelectionMode" Value="Single" />
+
+                <Setter Property="VerticalScrollBarVisibility" Value="Visible" />
+                <Setter Property="ScrollViewer.CanContentScroll" Value="True" />
+
+
+                <Setter Property="HorizontalGridLinesBrush" Value="LightPink" />
+                <Setter Property="VerticalGridLinesBrush" Value="Transparent" />
+
+
+                <Style.Resources>
+                    <!--  DataGridColumnHeader  -->
+                    <Style TargetType="DataGridColumnHeader">
+                        <Setter Property="HorizontalContentAlignment" Value="Center" />
+                        <Setter Property="VerticalContentAlignment" Value="Center" />
+
+                        <Setter Property="FontFamily" Value="Roboto" />
+                        <Setter Property="FontSize" Value="16" />
+
+
+                        <Setter Property="Background" Value="MediumPurple" />
+                        <Setter Property="Foreground" Value="White" />
+                    </Style>
+
+
+                    <!--  DataGridRow  -->
+                    <Style TargetType="DataGridRow">
+                        <Setter Property="Height" Value="40" />
+                        <Setter Property="FontSize" Value="16" />
+
+
+                        <Style.Resources>
+                            <SolidColorBrush x:Key="{x:Static SystemColors.HighlightBrushKey}" Color="Lavender" />
+                            <SolidColorBrush x:Key="{x:Static SystemColors.ControlBrushKey}" Color="MediumPurple" />
+                            <SolidColorBrush x:Key="{x:Static SystemColors.HighlightTextBrushKey}" Color="Black" />
+                            <SolidColorBrush x:Key="{x:Static SystemColors.ControlTextBrushKey}" Color="Black" />
+                        </Style.Resources>
+                    </Style>
+
+                    <!--  DataGridCell  -->
+                    <Style TargetType="DataGridCell">
+                        <Setter Property="BorderThickness" Value="0" />
+                        <Setter Property="FocusVisualStyle" Value="{x:Null}" />
+                        <Style.Resources>
+                            <Style TargetType="ContentPresenter">
+                                <Setter Property="HorizontalAlignment" Value="Center" />
+                                <Setter Property="VerticalAlignment" Value="Center" />
+                            </Style>
+                        </Style.Resources>
+                    </Style>
+                </Style.Resources>
+            </Style>
+
+
+            <!--  SIDE PANEL DATA GRID Row  -->
+            <Style
+                x:Key="SidePanelDataGridRow"
+                BasedOn="{StaticResource MaterialDesignDataGridRow}"
+                TargetType="DataGridRow">
+                <Setter Property="Height" Value="40" />
+                <Setter Property="FontSize" Value="16" />
+
+
+                <Style.Resources>
+                    <SolidColorBrush x:Key="{x:Static SystemColors.HighlightBrushKey}" Color="Lavender" />
+                    <SolidColorBrush x:Key="{x:Static SystemColors.ControlBrushKey}" Color="MediumPurple" />
+                    <SolidColorBrush x:Key="{x:Static SystemColors.HighlightTextBrushKey}" Color="Black" />
+                    <SolidColorBrush x:Key="{x:Static SystemColors.ControlTextBrushKey}" Color="Black" />
+                </Style.Resources>
+            </Style>
+
+
+            <!--  DATA GRID BUTTON THAT IS VISIBLE ONLY ON ROW HOVER  -->
+            <Style
+                x:Key="DataGridButtonVisibleOnRowHover"
+                BasedOn="{StaticResource MaterialDesignRaisedButton}"
+                TargetType="Button">
+                <Setter Property="Visibility" Value="Collapsed" />
+                <Style.Triggers>
+                    <DataTrigger Binding="{Binding RelativeSource={RelativeSource AncestorType={x:Type DataGridRow}}, Path=IsMouseOver}" Value="True">
+                        <Setter Property="Visibility" Value="Visible" />
+                    </DataTrigger>
+                </Style.Triggers>
+            </Style>
         </ResourceDictionary>
     </Application.Resources>
 </Application>

--- a/HealthcareSystemFrontends/GraphicalEditor/App.xaml
+++ b/HealthcareSystemFrontends/GraphicalEditor/App.xaml
@@ -12,6 +12,107 @@
                 <ResourceDictionary Source="pack://application:,,,/MaterialDesignColors;component/Themes/Recommended/Primary/MaterialDesignColor.DeepPurple.xaml" />
                 <ResourceDictionary Source="pack://application:,,,/MaterialDesignColors;component/Themes/Recommended/Accent/MaterialDesignColor.Lime.xaml" />
             </ResourceDictionary.MergedDictionaries>
+
+
+            <!--  SIDE PANEL DATA GRID STYLE  -->
+            <!--  DataGrid  -->
+            <Style
+                x:Key="SidePanelDataGrid"
+                BasedOn="{StaticResource MaterialDesignDataGrid}"
+                TargetType="DataGrid">
+                <Setter Property="AutoGenerateColumns" Value="False" />
+                <Setter Property="CanUserAddRows" Value="False" />
+                <Setter Property="CanUserDeleteRows" Value="False" />
+                <Setter Property="CanUserReorderColumns" Value="False" />
+                <Setter Property="CanUserResizeColumns" Value="False" />
+                <Setter Property="CanUserResizeRows" Value="False" />
+                <Setter Property="ColumnHeaderHeight" Value="30" />
+                <Setter Property="HeadersVisibility" Value="Column" />
+                <Setter Property="IsReadOnly" Value="True" />
+                <Setter Property="SelectionMode" Value="Single" />
+
+                <Setter Property="VerticalScrollBarVisibility" Value="Visible" />
+                <Setter Property="ScrollViewer.CanContentScroll" Value="True" />
+
+
+                <Setter Property="HorizontalGridLinesBrush" Value="LightPink" />
+                <Setter Property="VerticalGridLinesBrush" Value="Transparent" />
+
+
+                <Style.Resources>
+                    <!--  DataGridColumnHeader  -->
+                    <Style TargetType="DataGridColumnHeader">
+                        <Setter Property="HorizontalContentAlignment" Value="Center" />
+                        <Setter Property="VerticalContentAlignment" Value="Center" />
+
+                        <Setter Property="FontFamily" Value="Roboto" />
+                        <Setter Property="FontSize" Value="16" />
+
+
+                        <Setter Property="Background" Value="MediumPurple" />
+                        <Setter Property="Foreground" Value="White" />
+                    </Style>
+
+
+                    <!--  DataGridRow  -->
+                    <Style TargetType="DataGridRow">
+                        <Setter Property="Height" Value="40" />
+                        <Setter Property="FontSize" Value="16" />
+
+
+                        <Style.Resources>
+                            <SolidColorBrush x:Key="{x:Static SystemColors.HighlightBrushKey}" Color="Lavender" />
+                            <SolidColorBrush x:Key="{x:Static SystemColors.ControlBrushKey}" Color="MediumPurple" />
+                            <SolidColorBrush x:Key="{x:Static SystemColors.HighlightTextBrushKey}" Color="Black" />
+                            <SolidColorBrush x:Key="{x:Static SystemColors.ControlTextBrushKey}" Color="Black" />
+                        </Style.Resources>
+                    </Style>
+
+                    <!--  DataGridCell  -->
+                    <Style TargetType="DataGridCell">
+                        <Setter Property="BorderThickness" Value="0" />
+                        <Setter Property="FocusVisualStyle" Value="{x:Null}" />
+                        <Style.Resources>
+                            <Style TargetType="ContentPresenter">
+                                <Setter Property="HorizontalAlignment" Value="Center" />
+                                <Setter Property="VerticalAlignment" Value="Center" />
+                            </Style>
+                        </Style.Resources>
+                    </Style>
+                </Style.Resources>
+            </Style>
+
+
+            <!--  SIDE PANEL DATA GRID Row  -->
+            <Style
+                x:Key="SidePanelDataGridRow"
+                BasedOn="{StaticResource MaterialDesignDataGridRow}"
+                TargetType="DataGridRow">
+                <Setter Property="Height" Value="40" />
+                <Setter Property="FontSize" Value="16" />
+
+
+                <Style.Resources>
+                    <SolidColorBrush x:Key="{x:Static SystemColors.HighlightBrushKey}" Color="Lavender" />
+                    <SolidColorBrush x:Key="{x:Static SystemColors.ControlBrushKey}" Color="MediumPurple" />
+                    <SolidColorBrush x:Key="{x:Static SystemColors.HighlightTextBrushKey}" Color="Black" />
+                    <SolidColorBrush x:Key="{x:Static SystemColors.ControlTextBrushKey}" Color="Black" />
+                </Style.Resources>
+            </Style>
+
+
+            <!--  DATA GRID BUTTON THAT IS VISIBLE ONLY ON ROW HOVER  -->
+            <Style
+                x:Key="DataGridButtonVisibleOnRowHover"
+                BasedOn="{StaticResource MaterialDesignRaisedButton}"
+                TargetType="Button">
+                <Setter Property="Visibility" Value="Collapsed" />
+                <Style.Triggers>
+                    <DataTrigger Binding="{Binding RelativeSource={RelativeSource AncestorType={x:Type DataGridRow}}, Path=IsMouseOver}" Value="True">
+                        <Setter Property="Visibility" Value="Visible" />
+                    </DataTrigger>
+                </Style.Triggers>
+            </Style>
         </ResourceDictionary>
     </Application.Resources>
 </Application>

--- a/HealthcareSystemFrontends/GraphicalEditor/Converters/CapitalizeStringConverter.cs
+++ b/HealthcareSystemFrontends/GraphicalEditor/Converters/CapitalizeStringConverter.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Data;
+
+namespace GraphicalEditor.Converters
+{
+    class CapitalizeStringConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            String text = value.ToString();
+            Console.WriteLine(text.GetType() == typeof(String));
+
+            if (String.IsNullOrEmpty(text))
+            {
+                return "";
+            }
+
+            text = text.First().ToString().ToUpper() + text.ToLower().Substring(1);
+            Console.WriteLine(text);
+
+            return text;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/HealthcareSystemFrontends/GraphicalEditor/Converters/NegativeEquipmentQuantityConverter.cs
+++ b/HealthcareSystemFrontends/GraphicalEditor/Converters/NegativeEquipmentQuantityConverter.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Data;
+
+namespace GraphicalEditor.Converters
+{
+    class NegativeEquipmentQuantityConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            String quantity = value.ToString();
+
+            if (String.IsNullOrEmpty(quantity))
+            {
+                return "";
+            }
+
+            if (quantity.Contains("-"))
+                quantity = quantity.Replace("-", "");
+         
+            return quantity;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/HealthcareSystemFrontends/GraphicalEditor/GraphicalEditor.csproj
+++ b/HealthcareSystemFrontends/GraphicalEditor/GraphicalEditor.csproj
@@ -71,6 +71,8 @@
     </ApplicationDefinition>
     <Compile Include="Constants\ServerConstants.cs" />
     <Compile Include="Controllers\MapObjectController\MapObjectController.cs" />
+    <Compile Include="Converters\CapitalizeStringConverter.cs" />
+    <Compile Include="Converters\NegativeEquipmentQuantityConverter.cs" />
     <Compile Include="DTO\EquipmentWithRoomDTO.cs" />
     <Compile Include="Enumerations\BuildingLayersButtonsOrientation.cs" />
     <Compile Include="Models\Equipment\Equipment.cs" />

--- a/HealthcareSystemFrontends/GraphicalEditor/MainWindow.xaml
+++ b/HealthcareSystemFrontends/GraphicalEditor/MainWindow.xaml
@@ -2,6 +2,7 @@
     x:Class="GraphicalEditor.MainWindow"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:converters="clr-namespace:GraphicalEditor.Converters"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:local="clr-namespace:GraphicalEditor"
     xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
@@ -20,23 +21,24 @@
     WindowState="Maximized"
     mc:Ignorable="d">
 
-
-
-
-
-
+    <Window.Resources>
+        <converters:NegativeEquipmentQuantityConverter x:Key="NegativeEquipmentQuantityConverter" />
+        <converters:CapitalizeStringConverter x:Key="CapitalizeStringConverter" />
+    </Window.Resources>
 
     <DockPanel>
         <StackPanel Margin="20,20,0,0" DockPanel.Dock="Left">
-            <Canvas
-                x:Name="Canvas"
-                Width="1086"
-                Height="700"
-                HorizontalAlignment="Center"
-                VerticalAlignment="Bottom"
-                Background="#D9FFBF"
-                MouseDown="Canvas_MouseDown"
-                MouseMove="Canvas_MouseMove" />
+            <materialDesign:TransitioningContent x:Name="ShowMapCanvasEffect" OpeningEffect="{materialDesign:TransitionEffect Kind=ExpandIn, Duration=0:0:0.3}">
+                <Canvas
+                    x:Name="Canvas"
+                    Width="1086"
+                    Height="700"
+                    HorizontalAlignment="Center"
+                    VerticalAlignment="Bottom"
+                    Background="#D9FFBF"
+                    MouseDown="Canvas_MouseDown"
+                    MouseMove="Canvas_MouseMove" />
+            </materialDesign:TransitioningContent>
 
             <Grid Margin="0,5,0,0">
                 <Grid.RowDefinitions>
@@ -221,11 +223,11 @@
             Margin="0,20,0,50"
             Padding="10,0,10,0"
             DockPanel.Dock="Right">
-            <StackPanel x:Name="InformationDisplay">
+            <Grid x:Name="InformationDisplay">
 
-                <StackPanel.Resources>
+                <Grid.Resources>
 
-                    <Style x:Key="NormalMode" TargetType="StackPanel">
+                    <Style x:Key="NormalMode" TargetType="Grid">
                         <Style.Triggers>
                             <DataTrigger Binding="{Binding EditMode}" Value="False">
                                 <Setter Property="Visibility" Value="Visible" />
@@ -272,7 +274,7 @@
                         </Style.Triggers>
                     </Style>
 
-                    <Style x:Key="MenuClosed" TargetType="StackPanel">
+                    <Style x:Key="MenuClosed" TargetType="Grid">
                         <Style.Triggers>
                             <DataTrigger Binding="{Binding IsMenuOpened}" Value="False">
                                 <Setter Property="Visibility" Value="Visible" />
@@ -283,7 +285,7 @@
                         </Style.Triggers>
                     </Style>
 
-                    <Style x:Key="NoSelectionObjectInfoPanel" TargetType="StackPanel">
+                    <Style x:Key="NoSelectionObjectInfoPanel" TargetType="Grid">
                         <!--  Show panel regularly  -->
                         <Setter Property="Visibility" Value="Visible" />
                         <Style.Triggers>
@@ -295,7 +297,7 @@
                     </Style>
 
 
-                    <Style x:Key="ObjectInfoPanelSelectedFromMenu" TargetType="StackPanel">
+                    <Style x:Key="ObjectInfoPanelSelectedFromMenu" TargetType="Grid">
                         <Setter Property="Visibility" Value="Collapsed" />
                         <Style.Triggers>
                             <DataTrigger Binding="{Binding SelectedMenuOptionIndex}" Value="0">
@@ -304,7 +306,7 @@
                         </Style.Triggers>
                     </Style>
 
-                    <Style x:Key="SearchObjectsPanelSelectedFromMenu" TargetType="StackPanel">
+                    <Style x:Key="SearchObjectsPanelSelectedFromMenu" TargetType="Grid">
                         <Setter Property="Visibility" Value="Collapsed" />
                         <Style.Triggers>
                             <DataTrigger Binding="{Binding SelectedMenuOptionIndex}" Value="1">
@@ -313,7 +315,7 @@
                         </Style.Triggers>
                     </Style>
 
-                    <Style x:Key="SearchEquipmentAndMedicinePanelSelectedFromMenu" TargetType="StackPanel">
+                    <Style x:Key="SearchEquipmentAndMedicinePanelSelectedFromMenu" TargetType="Grid">
                         <Setter Property="Visibility" Value="Collapsed" />
                         <Style.Triggers>
                             <DataTrigger Binding="{Binding SelectedMenuOptionIndex}" Value="2">
@@ -322,7 +324,7 @@
                         </Style.Triggers>
                     </Style>
 
-                    <Style x:Key="SearchAppointmentsPanelSelectedFromMenu" TargetType="StackPanel">
+                    <Style x:Key="SearchAppointmentsPanelSelectedFromMenu" TargetType="Grid">
                         <Setter Property="Visibility" Value="Collapsed" />
                         <Style.Triggers>
                             <DataTrigger Binding="{Binding SelectedMenuOptionIndex}" Value="3">
@@ -330,16 +332,16 @@
                             </DataTrigger>
                         </Style.Triggers>
                     </Style>
-                </StackPanel.Resources>
+                </Grid.Resources>
 
-
-                <StackPanel>
+                <!--  SIDE PANEL CONTAINER GRID  -->
+                <Grid>
                     <!--  MENU  -->
-                    <StackPanel
-                        x:Name="MenuPanel"
-                        VerticalAlignment="Top"
-                        Style="{StaticResource MenuOpened}">
-                        <Grid>
+                    <materialDesign:TransitioningContent x:Name="ShowMenuSlide" OpeningEffect="{materialDesign:TransitionEffect Kind=SlideInFromTop, Duration=0:0:0.2}">
+                        <StackPanel
+                            x:Name="MenuPanel"
+                            VerticalAlignment="Top"
+                            Style="{StaticResource MenuOpened}">
                             <Button
                                 x:Name="CloseMenuButton"
                                 Width="Auto"
@@ -355,225 +357,242 @@
                                     Foreground="MediumPurple"
                                     Kind="Close" />
                             </Button>
-                        </Grid>
-                        <StackPanel>
-                            <ListView
-                                x:Name="ListViewExtendMenu"
-                                FontFamily="Roboto"
-                                FontSize="18"
-                                Foreground="#FF313131"
-                                ScrollViewer.HorizontalScrollBarVisibility="Disabled"
-                                SelectedIndex="{Binding SelectedMenuOptionIndex}"
-                                SelectionChanged="ListViewExtendMenu_SelectionChanged">
+                            <StackPanel>
+                                <ListView
+                                    x:Name="ListViewExtendMenu"
+                                    FontFamily="Roboto"
+                                    FontSize="18"
+                                    Foreground="#FF313131"
+                                    ScrollViewer.HorizontalScrollBarVisibility="Disabled"
+                                    SelectedIndex="{Binding SelectedMenuOptionIndex}"
+                                    SelectionChanged="ListViewExtendMenu_SelectionChanged">
 
-                                <ListViewItem
-                                    x:Name="DisplayAndEditObjectsMenuItem"
-                                    Height="60"
-                                    Padding="0">
-                                    <StackPanel Margin="10,0" Orientation="Horizontal">
-                                        <materialDesign:PackIcon
-                                            Width="30"
-                                            Height="30"
-                                            Margin="5"
-                                            VerticalAlignment="Center"
-                                            Foreground="MediumPurple"
-                                            Kind="FileDocumentEdit" />
-                                        <TextBlock
-                                            Margin="10"
-                                            VerticalAlignment="Center"
-                                            Foreground="MediumPurple"
-                                            Text="Prikaz i izmena informacija" />
-                                    </StackPanel>
-                                </ListViewItem>
+                                    <ListViewItem
+                                        x:Name="DisplayAndEditObjectsMenuItem"
+                                        Height="60"
+                                        Padding="0">
+                                        <StackPanel Margin="10,0" Orientation="Horizontal">
+                                            <materialDesign:PackIcon
+                                                Width="30"
+                                                Height="30"
+                                                Margin="5"
+                                                VerticalAlignment="Center"
+                                                Foreground="MediumPurple"
+                                                Kind="FileDocumentEdit" />
+                                            <TextBlock
+                                                Margin="10"
+                                                VerticalAlignment="Center"
+                                                Foreground="MediumPurple"
+                                                Text="Prikaz i izmena informacija" />
+                                        </StackPanel>
+                                    </ListViewItem>
 
-                                <ListViewItem
-                                    x:Name="SearchObjectsMenuItem"
-                                    Height="60"
-                                    Padding="0">
-                                    <StackPanel Margin="10,0" Orientation="Horizontal">
-                                        <materialDesign:PackIcon
-                                            Width="30"
-                                            Height="30"
-                                            Margin="5"
-                                            VerticalAlignment="Center"
-                                            Foreground="MediumPurple"
-                                            Kind="MapSearchOutline" />
-                                        <TextBlock
-                                            Margin="10"
-                                            VerticalAlignment="Center"
-                                            Foreground="MediumPurple"
-                                            Text="Pretraga objekata" />
-                                    </StackPanel>
-                                </ListViewItem>
+                                    <ListViewItem
+                                        x:Name="SearchObjectsMenuItem"
+                                        Height="60"
+                                        Padding="0">
+                                        <StackPanel Margin="10,0" Orientation="Horizontal">
+                                            <materialDesign:PackIcon
+                                                Width="30"
+                                                Height="30"
+                                                Margin="5"
+                                                VerticalAlignment="Center"
+                                                Foreground="MediumPurple"
+                                                Kind="MapSearchOutline" />
+                                            <TextBlock
+                                                Margin="10"
+                                                VerticalAlignment="Center"
+                                                Foreground="MediumPurple"
+                                                Text="Pretraga objekata" />
+                                        </StackPanel>
+                                    </ListViewItem>
 
-                                <ListViewItem
-                                    x:Name="SearchEquipmentAndMedicineMenuItem"
-                                    Height="60"
-                                    Padding="0">
-                                    <StackPanel
-                                        Margin="10,0"
-                                        HorizontalAlignment="Left"
-                                        Orientation="Horizontal">
-                                        <materialDesign:PackIcon
-                                            Width="30"
-                                            Height="30"
-                                            Margin="5,0,0,0"
-                                            VerticalAlignment="Center"
-                                            Foreground="MediumPurple"
-                                            Kind="SearchPlus" />
-                                        <TextBlock
-                                            Margin="10"
-                                            VerticalAlignment="Center"
-                                            FontSize="18"
-                                            Foreground="MediumPurple"
-                                            Text=" Pretraga opreme i lekova" />
-                                    </StackPanel>
-                                </ListViewItem>
+                                    <ListViewItem
+                                        x:Name="SearchEquipmentAndMedicineMenuItem"
+                                        Height="60"
+                                        Padding="0">
+                                        <StackPanel
+                                            Margin="10,0"
+                                            HorizontalAlignment="Left"
+                                            Orientation="Horizontal">
+                                            <materialDesign:PackIcon
+                                                Width="30"
+                                                Height="30"
+                                                Margin="5,0,0,0"
+                                                VerticalAlignment="Center"
+                                                Foreground="MediumPurple"
+                                                Kind="SearchPlus" />
+                                            <TextBlock
+                                                Margin="10"
+                                                VerticalAlignment="Center"
+                                                FontSize="18"
+                                                Foreground="MediumPurple"
+                                                Text=" Pretraga opreme i lekova" />
+                                        </StackPanel>
+                                    </ListViewItem>
 
-                                <ListViewItem
-                                    x:Name="SearchAppointmentsMenuItem"
-                                    Height="60"
-                                    Padding="0">
-                                    <StackPanel Margin="10,0" Orientation="Horizontal">
-                                        <materialDesign:PackIcon
-                                            Width="30"
-                                            Height="30"
-                                            Margin="5"
-                                            VerticalAlignment="Center"
-                                            Foreground="MediumPurple"
-                                            Kind="CalendarClock" />
-                                        <TextBlock
-                                            Margin="10"
-                                            VerticalAlignment="Center"
-                                            Foreground="MediumPurple"
-                                            Text="Pretraga termina" />
-                                    </StackPanel>
-                                </ListViewItem>
+                                    <ListViewItem
+                                        x:Name="SearchAppointmentsMenuItem"
+                                        Height="60"
+                                        Padding="0">
+                                        <StackPanel Margin="10,0" Orientation="Horizontal">
+                                            <materialDesign:PackIcon
+                                                Width="30"
+                                                Height="30"
+                                                Margin="5"
+                                                VerticalAlignment="Center"
+                                                Foreground="MediumPurple"
+                                                Kind="CalendarClock" />
+                                            <TextBlock
+                                                Margin="10"
+                                                VerticalAlignment="Center"
+                                                Foreground="MediumPurple"
+                                                Text="Pretraga termina" />
+                                        </StackPanel>
+                                    </ListViewItem>
 
-                                <ListViewItem Height="60" Padding="0">
-                                    <StackPanel Margin="10,0" Orientation="Horizontal">
-                                        <materialDesign:PackIcon
-                                            Width="30"
-                                            Height="30"
-                                            Margin="5"
-                                            VerticalAlignment="Center"
-                                            Foreground="MediumPurple"
-                                            Kind="InfoCircle" />
-                                        <TextBlock
-                                            Margin="10"
-                                            VerticalAlignment="Center"
-                                            Foreground="MediumPurple"
-                                            Text="O aplikaciji" />
-                                    </StackPanel>
-                                </ListViewItem>
+                                    <ListViewItem Height="60" Padding="0">
+                                        <StackPanel Margin="10,0" Orientation="Horizontal">
+                                            <materialDesign:PackIcon
+                                                Width="30"
+                                                Height="30"
+                                                Margin="5"
+                                                VerticalAlignment="Center"
+                                                Foreground="MediumPurple"
+                                                Kind="InfoCircle" />
+                                            <TextBlock
+                                                Margin="10"
+                                                VerticalAlignment="Center"
+                                                Foreground="MediumPurple"
+                                                Text="O aplikaciji" />
+                                        </StackPanel>
+                                    </ListViewItem>
 
-                            </ListView>
+                                </ListView>
+                            </StackPanel>
                         </StackPanel>
-                    </StackPanel>
+                    </materialDesign:TransitioningContent>
 
-                    <StackPanel x:Name="InfoAndEditingPanel" Style="{StaticResource MenuClosed}">
+
+                    <Grid x:Name="InfoAndEditingPanel" Style="{StaticResource MenuClosed}">
                         <!--  CONTAINER PANEL WITH MENU BUTTON  -->
-                        <StackPanel
-                            x:Name="NormalPanel"
-                            VerticalAlignment="Top"
-                            Style="{StaticResource NormalMode}">
+                        <materialDesign:TransitioningContent x:Name="PanelFromMenuSlide" OpeningEffect="{materialDesign:TransitionEffect Kind=SlideInFromRight, Duration=0:0:0.2}">
+                            <Grid x:Name="NormalPanel" Style="{StaticResource NormalMode}">
 
-                            <Button
-                                x:Name="OpenMenuButton"
-                                Width="Auto"
-                                Height="Auto"
-                                Margin="0,0,0,0"
-                                HorizontalAlignment="Right"
-                                VerticalAlignment="Top"
-                                Background="{x:Null}"
-                                BorderBrush="{x:Null}"
-                                Click="OpenMenuButton_Click"
-                                Style="{StaticResource EditingModeMenuButton}">
-                                <materialDesign:PackIcon
-                                    Width="50"
-                                    Height="50"
-                                    HorizontalAlignment="Center"
-                                    VerticalAlignment="Center"
-                                    Foreground="MediumPurple"
-                                    Kind="Menu" />
-                            </Button>
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="1*" />
+                                    <RowDefinition Height="10*" />
+                                </Grid.RowDefinitions>
 
-                            <!--  OBJECT INFO, EQUIPMENT AND MEDICINE CONTAINER PANEL  -->
-                            <StackPanel Style="{StaticResource ObjectInfoPanelSelectedFromMenu}">
-                                <StackPanel x:Name="ObjecInfoEquipmenMedicinePanel" Style="{StaticResource NoSelectionObjectInfoPanel}">
-                                    <!--  OBJECT INFO DISPLAY PANEL  -->
-                                    <StackPanel x:Name="ObjectInfoPanel">
-                                        <!--  OBJECT TYPE  -->
-                                        <TextBlock
-                                            HorizontalAlignment="Center"
-                                            VerticalAlignment="Center"
-                                            FontSize="26"
-                                            Text="{Binding DisplayMapObject.MapObjectType.ObjectTypeFullName}"
-                                            TextWrapping="Wrap" />
+                                <Button
+                                    x:Name="OpenMenuButton"
+                                    Grid.Row="0"
+                                    Width="Auto"
+                                    Height="Auto"
+                                    Margin="0,0,0,0"
+                                    HorizontalAlignment="Right"
+                                    VerticalAlignment="Top"
+                                    Background="{x:Null}"
+                                    BorderBrush="{x:Null}"
+                                    Click="OpenMenuButton_Click"
+                                    Style="{StaticResource EditingModeMenuButton}">
+                                    <materialDesign:PackIcon
+                                        Width="50"
+                                        Height="50"
+                                        HorizontalAlignment="Center"
+                                        VerticalAlignment="Center"
+                                        Foreground="MediumPurple"
+                                        Kind="Menu" />
+                                </Button>
 
+                                <!--  OBJECT INFO, EQUIPMENT AND MEDICINE CONTAINER PANEL  -->
+                                <Grid Grid.Row="1" Style="{StaticResource ObjectInfoPanelSelectedFromMenu}">
+                                    <Grid x:Name="ObjecInfoEquipmenMedicinePanel" Style="{StaticResource NoSelectionObjectInfoPanel}">
 
-                                        <!--  OBJECT ID  -->
-                                        <TextBlock
-                                            Margin="0,5,0,0"
-                                            HorizontalAlignment="Center"
-                                            VerticalAlignment="Top"
-                                            FontSize="20"
-                                            Text="{Binding DisplayMapObject.Id}" />
+                                        <Grid.RowDefinitions>
+                                            <RowDefinition Height="Auto" />
+                                            <RowDefinition Height="2*" />
+                                        </Grid.RowDefinitions>
 
-
-                                        <!--  OBJECT DESCRIPTION  -->
-                                        <TextBlock
-                                            x:Name="Prop"
-                                            Margin="0,20,0,0"
-                                            FontSize="16"
-                                            Text="{Binding DisplayMapObject.Description}"
-                                            TextWrapping="Wrap" />
-
-                                        <!--  OBJECT EDITING BUTTON  -->
-                                        <Button
-                                            x:Name="EditObjectButton"
-                                            Height="Auto"
-                                            Margin="0,30,0,0"
-                                            Padding="5"
-                                            Background="#7D80DA"
-                                            BorderBrush="{x:Null}"
-                                            Click="Edit_Display_Information"
-                                            FontSize="18">
-                                            <StackPanel
+                                        <!--  OBJECT INFO DISPLAY PANEL  -->
+                                        <StackPanel x:Name="ObjectInfoPanel" Grid.Row="0">
+                                            <!--  OBJECT TYPE  -->
+                                            <TextBlock
                                                 HorizontalAlignment="Center"
                                                 VerticalAlignment="Center"
-                                                Orientation="Horizontal">
-                                                <materialDesign:PackIcon
-                                                    Width="25"
-                                                    Height="25"
-                                                    HorizontalAlignment="Left"
-                                                    VerticalAlignment="Center"
-                                                    Foreground="White"
-                                                    Kind="Edit" />
-                                                <TextBlock
-                                                    Margin="5"
-                                                    HorizontalAlignment="Right"
-                                                    VerticalAlignment="Center"
-                                                    Foreground="White"
-                                                    Text="Izmeni" />
-                                            </StackPanel>
-                                        </Button>
-                                    </StackPanel>
+                                                FontSize="26"
+                                                Text="{Binding DisplayMapObject.MapObjectType.ObjectTypeFullName}"
+                                                TextWrapping="Wrap" />
 
-                                    <Separator Margin="0,20,0,20" Background="MediumPurple" />
 
-                                    <!--  OBJECT EQUIPMENT AND MEDICINE PANEL  -->
-                                    <StackPanel x:Name="ObjectEquipmentAndMedicinePanel">
-                                        <!--  OBJECT EQUIPMENT GRID  -->
-                                        <Grid x:Name="ObjectEquipmentGrid">
+                                            <!--  OBJECT ID  -->
+                                            <TextBlock
+                                                Margin="0,5,0,0"
+                                                HorizontalAlignment="Center"
+                                                VerticalAlignment="Top"
+                                                FontSize="20"
+                                                Text="{Binding DisplayMapObject.Id}" />
+
+
+                                            <!--  OBJECT DESCRIPTION  -->
+                                            <TextBlock
+                                                x:Name="Prop"
+                                                Margin="0,20,0,0"
+                                                FontSize="16"
+                                                Text="{Binding DisplayMapObject.Description}"
+                                                TextWrapping="Wrap" />
+
+                                            <!--  OBJECT EDITING BUTTON  -->
+                                            <Button
+                                                x:Name="EditObjectButton"
+                                                Height="Auto"
+                                                Margin="0,30,0,0"
+                                                Padding="5"
+                                                Background="#7D80DA"
+                                                BorderBrush="{x:Null}"
+                                                Click="Edit_Display_Information"
+                                                FontSize="18">
+                                                <StackPanel
+                                                    HorizontalAlignment="Center"
+                                                    VerticalAlignment="Center"
+                                                    Orientation="Horizontal">
+                                                    <materialDesign:PackIcon
+                                                        Width="25"
+                                                        Height="25"
+                                                        HorizontalAlignment="Left"
+                                                        VerticalAlignment="Center"
+                                                        Foreground="White"
+                                                        Kind="Edit" />
+                                                    <TextBlock
+                                                        Margin="5"
+                                                        HorizontalAlignment="Right"
+                                                        VerticalAlignment="Center"
+                                                        Foreground="White"
+                                                        Text="Izmeni" />
+                                                </StackPanel>
+                                            </Button>
+
+                                            <Separator Margin="0,20,0,20" Background="MediumPurple" />
+                                        </StackPanel>
+
+
+
+                                        <!--  OBJECT EQUIPMENT AND MEDICINE PANEL  -->
+                                        <Grid x:Name="ObjectEquipmentAndMedicinePanel" Grid.Row="1">
                                             <Grid.RowDefinitions>
-                                                <RowDefinition Height="1*" />
-                                                <RowDefinition Height="6*" />
+                                                <RowDefinition Height="*" />
+                                                <RowDefinition Height="3*" />
+                                                <RowDefinition Height="*" />
+                                                <RowDefinition Height="*" />
+                                                <RowDefinition Height="3*" />
+                                                <RowDefinition Height="*" />
                                             </Grid.RowDefinitions>
 
+                                            <!--  OBJECT EQUIPMENT SECTION  -->
                                             <TextBlock
                                                 Grid.Row="0"
                                                 Margin="0,0,0,10"
+                                                VerticalAlignment="Bottom"
                                                 FontSize="18"
                                                 FontWeight="Normal"
                                                 Foreground="Black">
@@ -585,89 +604,42 @@
                                                 x:Name="ObjectEquipmentDataGrid"
                                                 Grid.Row="1"
                                                 Margin="0,0,0,0"
-                                                AutoGenerateColumns="False"
-                                                CanUserAddRows="False"
-                                                CanUserDeleteRows="False"
-                                                CanUserReorderColumns="False"
-                                                CanUserResizeColumns="False"
-                                                CanUserResizeRows="False"
-                                                ColumnHeaderHeight="30"
-                                                FontFamily="Roboto"
-                                                HeadersVisibility="Column"
-                                                HorizontalGridLinesBrush="#C5E3BF"
-                                                IsReadOnly="True"
-                                                ItemsSource="{Binding DisplayMapObject}"
-                                                SelectionMode="Single"
-                                                VerticalGridLinesBrush="Transparent"
-                                                VerticalScrollBarVisibility="Visible">
-
-                                                <!--  Styling DataGrid  -->
+                                                Style="{StaticResource SidePanelDataGrid}">
                                                 <DataGrid.Resources>
-                                                    <Style TargetType="DataGridColumnHeader">
-                                                        <Setter Property="Background" Value="MediumPurple" />
-                                                        <Setter Property="Foreground" Value="White" />
-                                                        <Setter Property="FontFamily" Value="Roboto" />
-                                                        <Setter Property="FontSize" Value="16" />
-                                                        <Setter Property="HorizontalContentAlignment" Value="Center" />
-                                                        <Setter Property="VerticalContentAlignment" Value="Center" />
-                                                    </Style>
+                                                    <Style BasedOn="{StaticResource SidePanelDataGridRow}" TargetType="DataGridRow">
 
-                                                    <!--  Styling DataGrid  Rows  -->
-                                                    <Style TargetType="DataGridRow">
-                                                        <Setter Property="Height" Value="40" />
-                                                        <Setter Property="FontSize" Value="16" />
-
-                                                        <Style.Resources>
-                                                            <SolidColorBrush x:Key="{x:Static SystemColors.HighlightBrushKey}" Color="LightBlue" />
-                                                            <SolidColorBrush x:Key="{x:Static SystemColors.ControlBrushKey}" Color="Green" />
-                                                            <SolidColorBrush x:Key="{x:Static SystemColors.HighlightTextBrushKey}" Color="Black" />
-                                                            <SolidColorBrush x:Key="{x:Static SystemColors.ControlTextBrushKey}" Color="Black" />
-                                                        </Style.Resources>
+                                                        <Setter Property="ToolTip">
+                                                            <Setter.Value>
+                                                                <TextBlock Text="{Binding Type, Converter={StaticResource CapitalizeStringConverter}}" />
+                                                            </Setter.Value>
+                                                        </Setter>
                                                     </Style>
                                                 </DataGrid.Resources>
-
-                                                <!--  Styling DataGrid Cells  -->
-                                                <DataGrid.CellStyle>
-                                                    <Style TargetType="DataGridCell">
-                                                        <Setter Property="BorderThickness" Value="0" />
-                                                        <Setter Property="FocusVisualStyle" Value="{x:Null}" />
-                                                        <Style.Resources>
-                                                            <Style TargetType="ContentPresenter">
-                                                                <Setter Property="HorizontalAlignment" Value="Center" />
-                                                                <Setter Property="VerticalAlignment" Value="Center" />
-                                                            </Style>
-                                                        </Style.Resources>
-                                                    </Style>
-                                                </DataGrid.CellStyle>
-
 
                                                 <!--  Table Column Headers Names and Binding  -->
                                                 <DataGrid.Columns>
                                                     <DataGridTextColumn
                                                         Width="3*"
-                                                        Binding="{Binding DisplayMapObject.Id}"
+                                                        Binding="{Binding Type, Converter={StaticResource CapitalizeStringConverter}}"
                                                         Header="Naziv opreme" />
                                                     <DataGridTextColumn
                                                         Width="1*"
-                                                        Binding="{Binding DisplayMapObject.MapObjectType.ObjectTypeFullName}"
+                                                        Binding="{Binding Quantity, Converter={StaticResource NegativeEquipmentQuantityConverter}}"
                                                         Header="Količina" />
                                                 </DataGrid.Columns>
                                             </DataGrid>
-                                        </Grid>
 
 
-                                        <Separator Margin="0,20,0,20" Background="MediumPurple" />
+                                            <Separator
+                                                Grid.Row="2"
+                                                Margin="0,0,0,0"
+                                                Background="MediumPurple" />
 
-                                        <!--  OBJECT MEDICINE GRID  -->
-                                        <Grid x:Name="ObjectMedicineGrid">
-                                            <Grid.RowDefinitions>
-                                                <RowDefinition Height="1*" />
-                                                <RowDefinition Height="6*" />
-                                            </Grid.RowDefinitions>
-
+                                            <!--  OBJECT MEDICINE SECTION  -->
                                             <TextBlock
-                                                Grid.Row="0"
+                                                Grid.Row="3"
                                                 Margin="0,0,0,10"
+                                                VerticalAlignment="Bottom"
                                                 FontSize="18"
                                                 FontWeight="Normal"
                                                 Foreground="Black">
@@ -677,138 +649,209 @@
                                             <!--  OBJECT MEDICINE TABLE  -->
                                             <DataGrid
                                                 x:Name="ObjectMedicineDataGrid"
-                                                Grid.Row="1"
+                                                Grid.Row="4"
                                                 Margin="0,0,0,0"
-                                                AutoGenerateColumns="False"
-                                                CanUserAddRows="False"
-                                                CanUserDeleteRows="False"
-                                                CanUserReorderColumns="False"
-                                                CanUserResizeColumns="False"
-                                                CanUserResizeRows="False"
-                                                ColumnHeaderHeight="30"
-                                                FontFamily="Roboto"
-                                                HeadersVisibility="Column"
-                                                HorizontalGridLinesBrush="#C5E3BF"
-                                                IsReadOnly="True"
-                                                ItemsSource="{Binding DisplayMapObject}"
-                                                SelectionMode="Single"
-                                                VerticalGridLinesBrush="Transparent"
-                                                VerticalScrollBarVisibility="Visible">
-
-                                                <!--  Styling DataGrid  -->
+                                                Style="{StaticResource SidePanelDataGrid}">
                                                 <DataGrid.Resources>
-                                                    <Style TargetType="DataGridColumnHeader">
-                                                        <Setter Property="Background" Value="MediumPurple" />
-                                                        <Setter Property="Foreground" Value="White" />
-                                                        <Setter Property="FontFamily" Value="Roboto" />
-                                                        <Setter Property="FontSize" Value="16" />
-                                                        <Setter Property="HorizontalContentAlignment" Value="Center" />
-                                                        <Setter Property="VerticalContentAlignment" Value="Center" />
-                                                    </Style>
+                                                    <Style BasedOn="{StaticResource SidePanelDataGridRow}" TargetType="DataGridRow">
 
-                                                    <!--  Styling DataGrid  Rows  -->
-                                                    <Style TargetType="DataGridRow">
-                                                        <Setter Property="Height" Value="40" />
-                                                        <Setter Property="FontSize" Value="16" />
-
-                                                        <Style.Resources>
-                                                            <SolidColorBrush x:Key="{x:Static SystemColors.HighlightBrushKey}" Color="LightBlue" />
-                                                            <SolidColorBrush x:Key="{x:Static SystemColors.ControlBrushKey}" Color="Green" />
-                                                            <SolidColorBrush x:Key="{x:Static SystemColors.HighlightTextBrushKey}" Color="Black" />
-                                                            <SolidColorBrush x:Key="{x:Static SystemColors.ControlTextBrushKey}" Color="Black" />
-                                                        </Style.Resources>
+                                                        <Setter Property="ToolTip">
+                                                            <Setter.Value>
+                                                                <TextBlock Text="{Binding Name}" />
+                                                            </Setter.Value>
+                                                        </Setter>
                                                     </Style>
                                                 </DataGrid.Resources>
 
-                                                <!--  Styling DataGrid Cells  -->
-                                                <DataGrid.CellStyle>
-                                                    <Style TargetType="DataGridCell">
-                                                        <Setter Property="BorderThickness" Value="0" />
-                                                        <Setter Property="FocusVisualStyle" Value="{x:Null}" />
-                                                        <Style.Resources>
-                                                            <Style TargetType="ContentPresenter">
-                                                                <Setter Property="HorizontalAlignment" Value="Center" />
-                                                                <Setter Property="VerticalAlignment" Value="Center" />
-                                                            </Style>
-                                                        </Style.Resources>
-                                                    </Style>
-                                                </DataGrid.CellStyle>
-
-
                                                 <!--  Table Column Headers Names and Binding  -->
                                                 <DataGrid.Columns>
-                                                    <DataGridTextColumn Width="3*" Header="Naziv leka" />
-                                                    <!--  Binding="{Binding DisplayMapObject.Id}"  -->
-                                                    <DataGridTextColumn Width="1*" Header="Količina" />
-                                                    <!--  Binding="{Binding DisplayMapObject.MapObjectType.ObjectTypeFullName}"  -->
+                                                    <DataGridTextColumn
+                                                        Width="3*"
+                                                        Binding="{Binding Name}"
+                                                        Header="Naziv leka" />
+                                                    <DataGridTextColumn
+                                                        Width="1*"
+                                                        Binding="{Binding Quantity, Converter={StaticResource NegativeEquipmentQuantityConverter}}"
+                                                        Header="Količina" />
                                                 </DataGrid.Columns>
                                             </DataGrid>
                                         </Grid>
-                                    </StackPanel>
-                                </StackPanel>
-                            </StackPanel>
 
-                            <!--  SEARCH OBJECTS PANEL  -->
-                            <StackPanel x:Name="SearchObjectsPanel" Style="{StaticResource SearchObjectsPanelSelectedFromMenu}">
-                                <StackPanel>
-                                    <TextBlock
-                                        HorizontalAlignment="Left"
-                                        VerticalAlignment="Center"
-                                        FontSize="26"
-                                        Text="Pretraga objekata: "
-                                        TextWrapping="Wrap" />
+                                    </Grid>
+                                </Grid>
 
-                                    <ComboBox
-                                        Name="SearchObjectTypeComboBox"
-                                        Margin="0,20,0,0"
-                                        materialDesign:HintAssist.Hint="Izaberite tip objekta."
-                                        FontSize="16">
-                                        <!--  ItemsSource="{Binding DisplayMapObject.MapObjectType.AllMapObjectTypesAvailableToChange}">  -->
-                                        <ComboBox.ItemTemplate>
-                                            <DataTemplate>
-                                                <!-- <TextBlock Text="{Binding Path=ObjectTypeFullName}" /> -->
-                                            </DataTemplate>
-                                        </ComboBox.ItemTemplate>
-                                    </ComboBox>
+                                <!--  SEARCH OBJECTS PANEL  -->
+                                <Grid
+                                    x:Name="SearchObjectsPanel"
+                                    Grid.Row="1"
+                                    Style="{StaticResource SearchObjectsPanelSelectedFromMenu}">
+                                    <Grid>
+                                        <Grid.RowDefinitions>
+                                            <RowDefinition Height="1*" />
+                                            <RowDefinition Height="2*" />
+                                            <RowDefinition Height="1*" />
+                                            <RowDefinition Height="1*" />
+                                            <RowDefinition Height="1*" />
+                                            <RowDefinition Height="9*" />
+                                            <RowDefinition Height="1*" />
+                                        </Grid.RowDefinitions>
 
-
-                                    <!--  SEARCH OBJECTS BUTTON  -->
-                                    <Button
-                                        x:Name="SearchObjectsButton"
-                                        Height="Auto"
-                                        Margin="0,30,0,0"
-                                        Padding="5"
-                                        Background="#7D80DA"
-                                        BorderBrush="{x:Null}"
-                                        FontSize="18">
-                                        <StackPanel
-                                            HorizontalAlignment="Center"
+                                        <TextBlock
+                                            Grid.Row="0"
+                                            HorizontalAlignment="Left"
                                             VerticalAlignment="Center"
-                                            Orientation="Horizontal">
-                                            <materialDesign:PackIcon
-                                                Width="25"
-                                                Height="25"
-                                                HorizontalAlignment="Left"
-                                                VerticalAlignment="Center"
-                                                Foreground="White"
-                                                Kind="MapSearchOutline" />
-                                            <TextBlock
-                                                Margin="5"
-                                                HorizontalAlignment="Right"
-                                                VerticalAlignment="Center"
-                                                Foreground="White"
-                                                Text="Pretraži objekte" />
-                                        </StackPanel>
-                                    </Button>
+                                            FontSize="26"
+                                            Text="Pretraga objekata: "
+                                            TextWrapping="Wrap" />
 
-                                    <Separator Margin="0,20,0,20" Background="MediumPurple" />
-                                </StackPanel>
-                            </StackPanel>
+                                        <ComboBox
+                                            Name="SearchObjectTypeComboBox"
+                                            Grid.Row="1"
+                                            Margin="0,20,0,0"
+                                            materialDesign:HintAssist.Hint="Izaberite tip objekta."
+                                            FontSize="16"
+                                            ItemsSource="{Binding AllMapObjectTypes}">
+                                            <ComboBox.ItemTemplate>
+                                                <DataTemplate>
+                                                    <TextBlock Text="{Binding Path=ObjectTypeFullName}" />
+                                                </DataTemplate>
+                                            </ComboBox.ItemTemplate>
+                                        </ComboBox>
 
-                            <!--  SEARCH EQUIPMENT AND MEDICINE PANEL  -->
-                            <StackPanel x:Name="SearchEquipmentAndMedicinePanel" Style="{StaticResource SearchEquipmentAndMedicinePanelSelectedFromMenu}">
-                                <StackPanel>
+
+                                        <!--  SEARCH OBJECTS BUTTON  -->
+                                        <Button
+                                            x:Name="SearchMapObjectsButton"
+                                            Grid.Row="2"
+                                            Height="Auto"
+                                            Margin="0,0,0,0"
+                                            Padding="5"
+                                            Background="#7D80DA"
+                                            BorderBrush="{x:Null}"
+                                            Click="SearchMapObjectsButton_Click"
+                                            FontSize="18">
+                                            <StackPanel
+                                                HorizontalAlignment="Center"
+                                                VerticalAlignment="Center"
+                                                Orientation="Horizontal">
+                                                <materialDesign:PackIcon
+                                                    Width="25"
+                                                    Height="25"
+                                                    HorizontalAlignment="Left"
+                                                    VerticalAlignment="Center"
+                                                    Foreground="White"
+                                                    Kind="MapSearchOutline" />
+                                                <TextBlock
+                                                    Margin="5"
+                                                    HorizontalAlignment="Right"
+                                                    VerticalAlignment="Center"
+                                                    Foreground="White"
+                                                    Text="Pretraži objekte" />
+                                            </StackPanel>
+                                        </Button>
+
+                                        <Separator
+                                            Grid.Row="3"
+                                            Margin="0,0,0,0"
+                                            Background="MediumPurple" />
+
+                                        <!--  OBJECT SEARCH RESULTS SECTION  -->
+                                        <TextBlock
+                                            Grid.Row="4"
+                                            Margin="0,0,0,10"
+                                            VerticalAlignment="Bottom"
+                                            FontSize="18"
+                                            FontWeight="Normal"
+                                            Foreground="Black">
+                                            Rezultati pretrage:
+                                        </TextBlock>
+
+                                        <!--  OBJECT SEARCH RESULTS TABLE  -->
+                                        <DataGrid
+                                            x:Name="ObjectSearchResultsDataGrid"
+                                            Grid.Row="5"
+                                            Margin="0,0,0,0"
+                                            Style="{StaticResource SidePanelDataGrid}">
+                                            <DataGrid.Resources>
+                                                <Style BasedOn="{StaticResource SidePanelDataGridRow}" TargetType="DataGridRow">
+                                                    <Setter Property="ToolTip">
+                                                        <Setter.Value>
+                                                            <TextBlock Text="{Binding MapObjectEntity.Description}" />
+                                                        </Setter.Value>
+                                                    </Setter>
+                                                </Style>
+                                            </DataGrid.Resources>
+
+                                            <!--  Table Column Headers Names and Binding  -->
+                                            <DataGrid.Columns>
+                                                <DataGridTextColumn
+                                                    Width="1*"
+                                                    Binding="{Binding MapObjectEntity.Id}"
+                                                    Header="Id" />
+
+                                                <DataGridTextColumn
+                                                    Width="7*"
+                                                    Binding="{Binding MapObjectEntity.Description}"
+                                                    Header="Opis objekta" />
+
+                                                <DataGridTemplateColumn Width="Auto">
+                                                    <DataGridTemplateColumn.CellTemplate>
+                                                        <DataTemplate>
+                                                            <Button
+                                                                x:Name="ShowSearchResultObjectOnMapButton"
+                                                                Padding="3,0"
+                                                                HorizontalContentAlignment="Stretch"
+                                                                Background="MediumPurple"
+                                                                BorderBrush="{x:Null}"
+                                                                Click="ShowSearchResultObjectOnMapButton_Click"
+                                                                Style="{StaticResource DataGridButtonVisibleOnRowHover}">
+                                                                <StackPanel
+                                                                    HorizontalAlignment="Center"
+                                                                    VerticalAlignment="Center"
+                                                                    Orientation="Horizontal">
+                                                                    <materialDesign:PackIcon
+                                                                        Width="25"
+                                                                        Height="25"
+                                                                        HorizontalAlignment="Center"
+                                                                        VerticalAlignment="Center"
+                                                                        Foreground="White"
+                                                                        Kind="Location" />
+                                                                </StackPanel>
+                                                                <Button.ToolTip>
+                                                                    <ToolTip>
+                                                                        Prikaži objekat na mapi
+                                                                    </ToolTip>
+                                                                </Button.ToolTip>
+                                                            </Button>
+                                                        </DataTemplate>
+                                                    </DataGridTemplateColumn.CellTemplate>
+                                                </DataGridTemplateColumn>
+                                            </DataGrid.Columns>
+                                        </DataGrid>
+                                    </Grid>
+
+                                </Grid>
+
+                                <!--  SEARCH EQUIPMENT AND MEDICINE PANEL  -->
+                                <Grid
+                                    x:Name="SearchEquipmentAndMedicinePanel"
+                                    Grid.Row="1"
+                                    Style="{StaticResource SearchEquipmentAndMedicinePanelSelectedFromMenu}">
+
+                                    <Grid.RowDefinitions>
+                                        <RowDefinition Height="1*" />
+                                        <RowDefinition Height="1*" />
+                                        <RowDefinition Height="1*" />
+                                        <RowDefinition Height="1*" />
+                                        <RowDefinition Height="1*" />
+                                        <RowDefinition Height="3*" />
+                                        <RowDefinition Height="1*" />
+                                        <RowDefinition Height="3*" />
+                                        <RowDefinition Height="1*" />
+                                    </Grid.RowDefinitions>
+
                                     <TextBlock
+                                        Grid.Row="0"
                                         HorizontalAlignment="Left"
                                         VerticalAlignment="Center"
                                         FontSize="26"
@@ -816,7 +859,9 @@
                                         TextWrapping="Wrap" />
 
                                     <TextBox
-                                        Margin="0,20,0,0"
+                                        x:Name="EquipmentOrMedicineNameTextBox"
+                                        Grid.Row="1"
+                                        Margin="0,15,0,5"
                                         materialDesign:HintAssist.Hint="Unesite naziv opreme ili leka."
                                         FontSize="16"
                                         TextWrapping="Wrap" />
@@ -825,11 +870,14 @@
                                     <!--  SEARCH EQUIPMENT AND MEDICINE BUTTON  -->
                                     <Button
                                         x:Name="SearchEquimentAndMedicineButton"
+                                        Grid.Row="2"
                                         Height="Auto"
-                                        Margin="0,30,0,0"
+                                        Margin="0,0,0,0"
                                         Padding="5"
+                                        VerticalAlignment="Bottom"
                                         Background="#7D80DA"
                                         BorderBrush="{x:Null}"
+                                        Click="SearchEquimentAndMedicineButton_Click"
                                         FontSize="18">
                                         <StackPanel
                                             HorizontalAlignment="Center"
@@ -851,159 +899,362 @@
                                         </StackPanel>
                                     </Button>
 
-                                    <Separator Margin="0,20,0,20" Background="MediumPurple" />
-                                </StackPanel>
-                            </StackPanel>
+                                    <Separator
+                                        Grid.Row="3"
+                                        Margin="0,0,0,0"
+                                        Background="MediumPurple" />
 
-                            <!--  SEARCH APPOINTMENTS PANEL  -->
-                            <StackPanel x:Name="SearchAppointmentsPanel" Style="{StaticResource SearchAppointmentsPanelSelectedFromMenu}">
-                                <StackPanel>
+
+                                    <!--  EQUIPMENT AND MEDICINE SEARCH RESULTS SECTION  -->
                                     <TextBlock
-                                        HorizontalAlignment="Left"
-                                        VerticalAlignment="Center"
-                                        FontSize="26"
-                                        Text="Pretraga termina: "
-                                        TextWrapping="Wrap" />
+                                        Grid.Row="4"
+                                        Margin="0,0,0,10"
+                                        VerticalAlignment="Bottom"
+                                        FontSize="18"
+                                        FontWeight="Normal"
+                                        Foreground="Black">
+                                        Rezultati pretrage opreme:
+                                    </TextBlock>
 
-                                    <ComboBox
-                                        Name="AppointmentSearchDoctorComboBox"
-                                        Margin="0,20,0,0"
-                                        materialDesign:HintAssist.Hint="Izaberite lekara opšte prakse."
-                                        FontSize="16">
-                                        <!--  ItemsSource="{Binding DisplayMapObject.MapObjectType.AllMapObjectTypesAvailableToChange}">  -->
-                                        <ComboBox.ItemTemplate>
-                                            <DataTemplate>
-                                                <!-- <TextBlock Text="{Binding Path=ObjectTypeFullName}" /> -->
-                                            </DataTemplate>
-                                        </ComboBox.ItemTemplate>
-                                    </ComboBox>
+                                    <!--  EQUIPMENT SEARCH RESULTS TABLE  -->
+                                    <DataGrid
+                                        x:Name="EquipmentSearchResultsDataGrid"
+                                        Grid.Row="5"
+                                        Margin="0,0,0,0"
+                                        Style="{StaticResource SidePanelDataGrid}">
+                                        <DataGrid.Resources>
+                                            <Style BasedOn="{StaticResource SidePanelDataGridRow}" TargetType="DataGridRow">
+                                                <Setter Property="ToolTip">
+                                                    <Setter.Value>
+                                                        <TextBlock Text="{Binding Type, Converter={StaticResource CapitalizeStringConverter}}" />
+                                                    </Setter.Value>
+                                                </Setter>
+                                            </Style>
+                                        </DataGrid.Resources>
+
+                                        <!--  Table Column Headers Names and Binding  -->
+                                        <DataGrid.Columns>
+                                            <DataGridTextColumn
+                                                Width="3*"
+                                                Binding="{Binding Type, Converter={StaticResource CapitalizeStringConverter}}"
+                                                Header="Naziv" />
+
+                                            <DataGridTextColumn
+                                                Width="2*"
+                                                Binding="{Binding Quantity, Converter={StaticResource NegativeEquipmentQuantityConverter}}"
+                                                Header="Količina" />
+
+                                            <DataGridTextColumn
+                                                Width="2*"
+                                                Binding="{Binding RoomNumber}"
+                                                Header="Id objekta" />
+
+                                            <DataGridTemplateColumn Width="Auto">
+                                                <DataGridTemplateColumn.CellTemplate>
+                                                    <DataTemplate>
+                                                        <Button
+                                                            x:Name="ShowEquipmentSearchResultObjectOnMapButton"
+                                                            Padding="3,0"
+                                                            HorizontalContentAlignment="Stretch"
+                                                            Background="MediumPurple"
+                                                            BorderBrush="{x:Null}"
+                                                            Click="ShowEquipmentSearchResultObjectOnMapButton_Click"
+                                                            Style="{StaticResource DataGridButtonVisibleOnRowHover}">
+                                                            <StackPanel
+                                                                HorizontalAlignment="Center"
+                                                                VerticalAlignment="Center"
+                                                                Orientation="Horizontal">
+                                                                <materialDesign:PackIcon
+                                                                    Width="25"
+                                                                    Height="25"
+                                                                    HorizontalAlignment="Center"
+                                                                    VerticalAlignment="Center"
+                                                                    Foreground="White"
+                                                                    Kind="Location" />
+                                                            </StackPanel>
+                                                            <Button.ToolTip>
+                                                                <ToolTip>
+                                                                    Prikaži objekat na mapi
+                                                                </ToolTip>
+                                                            </Button.ToolTip>
+                                                        </Button>
+                                                    </DataTemplate>
+                                                </DataGridTemplateColumn.CellTemplate>
+                                            </DataGridTemplateColumn>
+                                        </DataGrid.Columns>
+                                    </DataGrid>
 
 
-                                    <!--  SEARCH EQUIPMENT AND MEDICINE BUTTON  -->
-                                    <Button
-                                        x:Name="SearchAppointmentsButton"
-                                        Height="Auto"
-                                        Margin="0,30,0,0"
-                                        Padding="5"
-                                        Background="#7D80DA"
-                                        BorderBrush="{x:Null}"
-                                        FontSize="18">
-                                        <StackPanel
-                                            HorizontalAlignment="Center"
+                                    <!--  MEDICINE SEARCH RESULTS SECTION  -->
+                                    <TextBlock
+                                        Grid.Row="6"
+                                        Margin="0,0,0,10"
+                                        VerticalAlignment="Bottom"
+                                        FontSize="18"
+                                        FontWeight="Normal"
+                                        Foreground="Black"
+                                        Text="Rezultati pretrage lekova:" />
+
+                                    <!--  MEDICINE SEARCH RESULTS TABLE  -->
+                                    <DataGrid
+                                        x:Name="MedicineSearchResultsDataGrid"
+                                        Grid.Row="7"
+                                        Margin="0,0,0,0"
+                                        Style="{StaticResource SidePanelDataGrid}">
+                                        <DataGrid.Resources>
+                                            <Style BasedOn="{StaticResource SidePanelDataGridRow}" TargetType="DataGridRow">
+                                                <Setter Property="ToolTip">
+                                                    <Setter.Value>
+                                                        <TextBlock Text="{Binding Name}" />
+                                                    </Setter.Value>
+                                                </Setter>
+                                            </Style>
+                                        </DataGrid.Resources>
+
+                                        <!--  Table Column Headers Names and Binding  -->
+                                        <DataGrid.Columns>
+                                            <DataGridTextColumn
+                                                Width="3*"
+                                                Binding="{Binding Name}"
+                                                Header="Naziv" />
+
+                                            <DataGridTextColumn
+                                                Width="2*"
+                                                Binding="{Binding Quantity, Converter={StaticResource NegativeEquipmentQuantityConverter}}"
+                                                Header="Količina" />
+
+                                            <DataGridTextColumn
+                                                Width="2*"
+                                                Binding="{Binding RoomNumber}"
+                                                Header="Id objekta" />
+
+                                            <DataGridTemplateColumn Width="Auto">
+                                                <DataGridTemplateColumn.CellTemplate>
+                                                    <DataTemplate>
+                                                        <Button
+                                                            x:Name="ShowMedicineSearchResultObjectOnMapButton"
+                                                            Padding="3,0"
+                                                            HorizontalContentAlignment="Stretch"
+                                                            Background="MediumPurple"
+                                                            BorderBrush="{x:Null}"
+                                                            Click="ShowMedicineSearchResultObjectOnMapButton_Click"
+                                                            Style="{StaticResource DataGridButtonVisibleOnRowHover}">
+                                                            <StackPanel
+                                                                HorizontalAlignment="Center"
+                                                                VerticalAlignment="Center"
+                                                                Orientation="Horizontal">
+                                                                <materialDesign:PackIcon
+                                                                    Width="25"
+                                                                    Height="25"
+                                                                    HorizontalAlignment="Center"
+                                                                    VerticalAlignment="Center"
+                                                                    Foreground="White"
+                                                                    Kind="Location" />
+                                                            </StackPanel>
+                                                            <Button.ToolTip>
+                                                                <ToolTip>
+                                                                    Prikaži objekat na mapi
+                                                                </ToolTip>
+                                                            </Button.ToolTip>
+                                                        </Button>
+                                                    </DataTemplate>
+                                                </DataGridTemplateColumn.CellTemplate>
+                                            </DataGridTemplateColumn>
+                                        </DataGrid.Columns>
+                                    </DataGrid>
+                                </Grid>
+
+
+                                <!--  SEARCH APPOINTMENTS PANEL  -->
+                                <Grid
+                                    x:Name="SearchAppointmentsPanel"
+                                    Grid.Row="1"
+                                    Style="{StaticResource SearchAppointmentsPanelSelectedFromMenu}">
+                                    <Grid>
+
+
+                                        <Grid.RowDefinitions>
+                                            <RowDefinition Height="1*" />
+                                            <RowDefinition Height="1*" />
+                                            <RowDefinition Height="1*" />
+                                            <RowDefinition Height="1*" />
+                                            <RowDefinition Height="1*" />
+                                            <RowDefinition Height="1*" />
+                                            <RowDefinition Height="1*" />
+                                            <RowDefinition Height="1*" />
+                                        </Grid.RowDefinitions>
+
+                                        <TextBlock
+                                            Grid.Row="0"
+                                            HorizontalAlignment="Left"
                                             VerticalAlignment="Center"
-                                            Orientation="Horizontal">
-                                            <materialDesign:PackIcon
-                                                Width="25"
-                                                Height="25"
-                                                HorizontalAlignment="Left"
+                                            FontSize="26"
+                                            Text="Pretraga termina: "
+                                            TextWrapping="Wrap" />
+
+                                        <ComboBox
+                                            Name="AppointmentSearchDoctorComboBox"
+                                            Grid.Row="1"
+                                            Margin="0,20,0,0"
+                                            materialDesign:HintAssist.Hint="Izaberite lekara opšte prakse."
+                                            FontSize="16">
+                                            <!--  ItemsSource="{Binding DisplayMapObject.MapObjectType.AllMapObjectTypesAvailableToChange}">  -->
+                                            <ComboBox.ItemTemplate>
+                                                <DataTemplate>
+                                                    <!-- <TextBlock Text="{Binding Path=ObjectTypeFullName}" /> -->
+                                                </DataTemplate>
+                                            </ComboBox.ItemTemplate>
+                                        </ComboBox>
+
+
+                                        <!--  SEARCH APPOINTMENTS BUTTON  -->
+                                        <Button
+                                            x:Name="SearchAppointmentsButton"
+                                            Grid.Row="2"
+                                            Height="Auto"
+                                            Margin="0,0,0,0"
+                                            Padding="5"
+                                            Background="#7D80DA"
+                                            BorderBrush="{x:Null}"
+                                            FontSize="18">
+                                            <StackPanel
+                                                HorizontalAlignment="Center"
                                                 VerticalAlignment="Center"
-                                                Foreground="White"
-                                                Kind="CalendarClock" />
-                                            <TextBlock
-                                                Margin="5"
-                                                HorizontalAlignment="Right"
-                                                VerticalAlignment="Center"
-                                                Foreground="White"
-                                                Text="Pretraži termine" />
-                                        </StackPanel>
-                                    </Button>
+                                                Orientation="Horizontal">
+                                                <materialDesign:PackIcon
+                                                    Width="25"
+                                                    Height="25"
+                                                    HorizontalAlignment="Left"
+                                                    VerticalAlignment="Center"
+                                                    Foreground="White"
+                                                    Kind="CalendarClock" />
+                                                <TextBlock
+                                                    Margin="5"
+                                                    HorizontalAlignment="Right"
+                                                    VerticalAlignment="Center"
+                                                    Foreground="White"
+                                                    Text="Pretraži termine" />
+                                            </StackPanel>
+                                        </Button>
 
-                                    <Separator Margin="0,20,0,20" Background="MediumPurple" />
-                                </StackPanel>
-                            </StackPanel>
+                                        <Separator
+                                            Grid.Row="3"
+                                            Margin="0,20,0,20"
+                                            Background="MediumPurple" />
+                                    </Grid>
+                                </Grid>
+                            </Grid>
+                        </materialDesign:TransitioningContent>
 
-
-                        </StackPanel>
 
                         <!--  OBJECT INFO EDITING INPUT PANEL  -->
-                        <StackPanel x:Name="EditPanel" Style="{StaticResource EditingMode}">
-                            <ComboBox
-                                Name="ObjectTypeChooserComboBox"
-                                materialDesign:HintAssist.Hint="Izaberite tip objekta."
-                                FontSize="16"
-                                ItemsSource="{Binding DisplayMapObject.MapObjectType.AllMapObjectTypesAvailableToChange}">
-                                <ComboBox.ItemTemplate>
-                                    <DataTemplate>
-                                        <TextBlock Text="{Binding Path=ObjectTypeFullName}" />
-                                    </DataTemplate>
-                                </ComboBox.ItemTemplate>
-                            </ComboBox>
+                        <Grid>
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="*" />
+                                <RowDefinition Height="10*" />
+                            </Grid.RowDefinitions>
 
-                            <TextBox
-                                Margin="0,5,0,0"
-                                HorizontalAlignment="Center"
-                                FontSize="20"
-                                IsReadOnly="True"
-                                Text="{Binding DisplayMapObject.Id}" />
+                            <StackPanel
+                                x:Name="EditPanel"
+                                Grid.Row="1"
+                                Style="{StaticResource EditingMode}">
 
-                            <TextBox
-                                Margin="0,10,0,0"
-                                materialDesign:HintAssist.Hint="Unesite deskripciju objekta."
-                                FontSize="16"
-                                Text="{Binding DisplayMapObject.Description}"
-                                TextWrapping="Wrap" />
-
-                            <Button
-                                x:Name="SaveButton"
-                                Height="Auto"
-                                Margin="0,15,0,0"
-                                Padding="5"
-                                Background="#7D80DA"
-                                BorderBrush="{x:Null}"
-                                Click="Change_Display_Information"
-                                FontSize="18">
-                                <StackPanel
-                                    HorizontalAlignment="Center"
+                                <TextBlock
+                                    Grid.Row="0"
+                                    HorizontalAlignment="Left"
                                     VerticalAlignment="Center"
-                                    Orientation="Horizontal">
-                                    <materialDesign:PackIcon
-                                        Width="25"
-                                        Height="25"
-                                        HorizontalAlignment="Left"
-                                        VerticalAlignment="Center"
-                                        Foreground="White"
-                                        Kind="ContentSave" />
-                                    <TextBlock
-                                        Margin="5"
-                                        HorizontalAlignment="Right"
-                                        VerticalAlignment="Center"
-                                        Foreground="White"
-                                        Text="Sačuvaj" />
-                                </StackPanel>
-                            </Button>
+                                    FontSize="26"
+                                    Text="Izmena objekta: "
+                                    TextWrapping="Wrap" />
+                                <ComboBox
+                                    Name="ObjectTypeChooserComboBox"
+                                    Margin="0,30,0,0"
+                                    materialDesign:HintAssist.Hint="Izaberite tip objekta."
+                                    FontSize="16"
+                                    ItemsSource="{Binding DisplayMapObject.MapObjectType.AllMapObjectTypesAvailableToChange}">
+                                    <ComboBox.ItemTemplate>
+                                        <DataTemplate>
+                                            <TextBlock Text="{Binding Path=ObjectTypeFullName}" />
+                                        </DataTemplate>
+                                    </ComboBox.ItemTemplate>
+                                </ComboBox>
 
-                            <Button
-                                Height="Auto"
-                                Margin="0,10,0,0"
-                                Padding="5"
-                                Background="#F2404C"
-                                BorderBrush="{x:Null}"
-                                Click="Cancel_Editing_Mode"
-                                FontSize="18">
-                                <StackPanel
+                                <TextBox
+                                    Margin="0,5,0,0"
                                     HorizontalAlignment="Center"
-                                    VerticalAlignment="Center"
-                                    Orientation="Horizontal">
-                                    <materialDesign:PackIcon
-                                        Width="25"
-                                        Height="25"
-                                        HorizontalAlignment="Left"
-                                        VerticalAlignment="Center"
-                                        Foreground="White"
-                                        Kind="CloseBox" />
-                                    <TextBlock
-                                        Margin="5"
-                                        HorizontalAlignment="Right"
-                                        VerticalAlignment="Center"
-                                        Foreground="White"
-                                        Text="Otkaži   " />
-                                </StackPanel>
-                            </Button>
+                                    FontSize="20"
+                                    IsReadOnly="True"
+                                    Text="{Binding DisplayMapObject.Id}" />
 
-                        </StackPanel>
-                    </StackPanel>
-                </StackPanel>
-            </StackPanel>
+                                <TextBox
+                                    Margin="0,10,0,0"
+                                    materialDesign:HintAssist.Hint="Unesite deskripciju objekta."
+                                    FontSize="16"
+                                    Text="{Binding DisplayMapObject.Description}"
+                                    TextWrapping="Wrap" />
+
+                                <Button
+                                    x:Name="SaveButton"
+                                    Height="Auto"
+                                    Margin="0,15,0,0"
+                                    Padding="5"
+                                    Background="#7D80DA"
+                                    BorderBrush="{x:Null}"
+                                    Click="Change_Display_Information"
+                                    FontSize="18">
+                                    <StackPanel
+                                        HorizontalAlignment="Center"
+                                        VerticalAlignment="Center"
+                                        Orientation="Horizontal">
+                                        <materialDesign:PackIcon
+                                            Width="25"
+                                            Height="25"
+                                            HorizontalAlignment="Left"
+                                            VerticalAlignment="Center"
+                                            Foreground="White"
+                                            Kind="ContentSave" />
+                                        <TextBlock
+                                            Margin="5"
+                                            HorizontalAlignment="Right"
+                                            VerticalAlignment="Center"
+                                            Foreground="White"
+                                            Text="Sačuvaj" />
+                                    </StackPanel>
+                                </Button>
+
+                                <Button
+                                    Height="Auto"
+                                    Margin="0,10,0,0"
+                                    Padding="5"
+                                    Background="#F2404C"
+                                    BorderBrush="{x:Null}"
+                                    Click="Cancel_Editing_Mode"
+                                    FontSize="18">
+                                    <StackPanel
+                                        HorizontalAlignment="Center"
+                                        VerticalAlignment="Center"
+                                        Orientation="Horizontal">
+                                        <materialDesign:PackIcon
+                                            Width="25"
+                                            Height="25"
+                                            HorizontalAlignment="Left"
+                                            VerticalAlignment="Center"
+                                            Foreground="White"
+                                            Kind="CloseBox" />
+                                        <TextBlock
+                                            Margin="5"
+                                            HorizontalAlignment="Right"
+                                            VerticalAlignment="Center"
+                                            Foreground="White"
+                                            Text="Otkaži   " />
+                                    </StackPanel>
+                                </Button>
+                            </StackPanel>
+                        </Grid>
+                    </Grid>
+
+                </Grid>
+            </Grid>
         </Border>
     </DockPanel>
 </Window>

--- a/HealthcareSystemFrontends/GraphicalEditor/MainWindow.xaml.cs
+++ b/HealthcareSystemFrontends/GraphicalEditor/MainWindow.xaml.cs
@@ -37,6 +37,7 @@ namespace GraphicalEditor
         public static Canvas _canvas;
         private MapObjectController _mapObjectController;
         public static List<MapObject> _allMapObjects;
+        public static List<MapObjectType> _allMapObjectTypes;
         private string _currentUserRole;
 
 
@@ -116,10 +117,24 @@ namespace GraphicalEditor
             }
         }
 
+        public List<MapObjectType> AllMapObjectTypes
+        {
+            get
+            {
+                return _allMapObjectTypes;
+            }
+            set
+            {
+                _allMapObjectTypes = value;
+                OnPropertyChanged("AllMapObjectTypes");
+            }
+        }
+
         public MainWindow()
         {
             InitializeComponent();
             this.DataContext = this;
+            AllMapObjectTypes = MapObjectType.AllMapObjectTypesAvailableForSearch;
             _canvas = this.Canvas;
             _fileRepository = new FileRepository("test.json");
             _mapObjectController = new MapObjectController(new MapObjectServices(_fileRepository));
@@ -130,7 +145,7 @@ namespace GraphicalEditor
             ChangeEditButtonVisibility();
 
             // uncomment only when you want to save the map for the first time
-            saveMap();
+            //saveMap();
 
             LoadInitialMapOnCanvas();
             // uncomment only the first time you start the project in order
@@ -153,6 +168,7 @@ namespace GraphicalEditor
         {
             InitializeComponent();
             this.DataContext = this;
+            AllMapObjectTypes = MapObjectType.AllMapObjectTypesAvailableForSearch;
             _currentUserRole = currentUserRole;
             _canvas = this.Canvas;
             _fileRepository = new FileRepository("test.json");
@@ -473,6 +489,31 @@ namespace GraphicalEditor
                     IsMenuOpened = false;
                     break;
             }
+        }
+
+        private void SearchEquimentAndMedicineButton_Click(object sender, RoutedEventArgs e)
+        {
+
+        }
+
+        private void SearchMapObjectsButton_Click(object sender, RoutedEventArgs e)
+        {
+
+        }
+
+        private void ShowEquipmentSearchResultObjectOnMapButton_Click(object sender, RoutedEventArgs e)
+        {
+
+        }
+
+        private void ShowMedicineSearchResultObjectOnMapButton_Click(object sender, RoutedEventArgs e)
+        {
+
+        }
+
+        private void ShowSearchResultObjectOnMapButton_Click(object sender, RoutedEventArgs e)
+        {
+
         }
     }
 }

--- a/HealthcareSystemFrontends/GraphicalEditor/Models/MapObjectRelated/MapObjectType.cs
+++ b/HealthcareSystemFrontends/GraphicalEditor/Models/MapObjectRelated/MapObjectType.cs
@@ -195,6 +195,26 @@ namespace GraphicalEditor.Models.MapObjectRelated
                 return allMapObjectTypesAvailableToChange;
             }
         }
+
+        public static List<MapObjectType> AllMapObjectTypesAvailableForSearch
+        {
+            get
+            {
+                List<MapObjectType> allMapObjectTypesAvailableToChange = new List<MapObjectType>();
+                Array typesOfMapObjects = Enum.GetValues(typeof(TypeOfMapObject));
+                foreach (TypeOfMapObject mapObjectType in typesOfMapObjects)
+                {
+                    if (mapObjectType != TypeOfMapObject.ROAD)
+                    {
+                        MapObjectType singleTypeOfMapObject = new MapObjectType(mapObjectType);
+                        allMapObjectTypesAvailableToChange.Add(singleTypeOfMapObject);
+                    }
+                }
+
+                return allMapObjectTypesAvailableToChange;
+            }
+        }
+
         public void SetStrokeColorAndThickness(Rectangle rectangle)
         {
             if (TypeOfMapObject != TypeOfMapObject.ROAD)

--- a/HealthcareSystemFrontends/GraphicalEditor/Models/MapObjectRelated/MockupObjects.cs
+++ b/HealthcareSystemFrontends/GraphicalEditor/Models/MapObjectRelated/MockupObjects.cs
@@ -37,7 +37,7 @@ namespace GraphicalEditor.Models.MapObjectRelated
         private void AddFirstBuildingToMap()
         {
             FirstBuilding = new MapObject(
-                  new Building(2, new BuildingLayersButtons(BuildingLayersButtonsOrientation.LEFT, 0, 0), "Building 1"),
+                  new Building(2, new BuildingLayersButtons(BuildingLayersButtonsOrientation.LEFT, 0, 0), "Building 1 se nalazi iza glavnog parkinga, sa leve strane restorana."),
                   new MapObjectMetrics(40, 50, 400, 250),
                   new MapObjectDoor(MapObjectDoorOrientation.BOTTOM, 20, 0)
           );
@@ -48,7 +48,7 @@ namespace GraphicalEditor.Models.MapObjectRelated
         private void AddSecondBuildingToMap()
         {
              SecondBuilding = new MapObject(
-                           new Building(2, new BuildingLayersButtons(BuildingLayersButtonsOrientation.BOTTOM, 0, 0), "Building 2"),
+                           new Building(2, new BuildingLayersButtons(BuildingLayersButtonsOrientation.BOTTOM, 0, 0), "Building 2 se nalazi sa desne strane restorana, na kraju kompleksa bolnice."),
                            new MapObjectMetrics(730, 50, 330, 612),
                            new MapObjectDoor(MapObjectDoorOrientation.LEFT, 0, 0)
                    );
@@ -60,7 +60,7 @@ namespace GraphicalEditor.Models.MapObjectRelated
         private void AddRestaurantToMap()
         {
             MapObject restaurant = new MapObject(
-                  new Restaurant(),
+                  new Restaurant("Restoran se nalazim izmedju Zgrade 1 i Zgrade 2."),
                   new MapObjectMetrics(485, 50, 200, 130),
                   new MapObjectDoor(MapObjectDoorOrientation.BOTTOM, 0, 0)
            );
@@ -72,7 +72,7 @@ namespace GraphicalEditor.Models.MapObjectRelated
         {
             MapObject operationRoom1InBuilding1GroundLevel = new MapObject(
                    new Room(
-                       TypeOfMapObject.OPERATION_ROOM, DepartmentOfMapObject.CARDIOLOGY, FirstBuilding, 0, "Operation room 1"
+                       TypeOfMapObject.OPERATION_ROOM, DepartmentOfMapObject.CARDIOLOGY, FirstBuilding, 0
                    ),
                    new MapObjectMetrics(40, 50, 200, 70),
                    new MapObjectDoor(MapObjectDoorOrientation.BOTTOM, 30, 0)
@@ -82,7 +82,7 @@ namespace GraphicalEditor.Models.MapObjectRelated
 
             MapObject operationRoom2InBuilding1GroundLevel = new MapObject(
                    new Room(
-                      TypeOfMapObject.OPERATION_ROOM, DepartmentOfMapObject.CARDIOLOGY, FirstBuilding, 0, "Operation room 2"
+                      TypeOfMapObject.OPERATION_ROOM, DepartmentOfMapObject.CARDIOLOGY, FirstBuilding, 0
                    ),
                    new MapObjectMetrics(240 - AllConstants.RECTANGLE_STROKE_THICKNESS, 50, 200 + AllConstants.RECTANGLE_STROKE_THICKNESS, 70),
                    new MapObjectDoor(MapObjectDoorOrientation.BOTTOM, 0, 30)
@@ -92,7 +92,7 @@ namespace GraphicalEditor.Models.MapObjectRelated
 
             MapObject examinationRoom1InBuilding1GroundLevel = new MapObject(
                     new Room(
-                         TypeOfMapObject.EXAMINATION_ROOM, DepartmentOfMapObject.CARDIOLOGY, FirstBuilding, 0, "Examiantion room 3"
+                         TypeOfMapObject.EXAMINATION_ROOM, DepartmentOfMapObject.CARDIOLOGY, FirstBuilding, 0
                     ),
                     new MapObjectMetrics(40, 120 - AllConstants.RECTANGLE_STROKE_THICKNESS, 80, 120 + AllConstants.RECTANGLE_STROKE_THICKNESS),
                     new MapObjectDoor(MapObjectDoorOrientation.RIGHT, 0, 0)
@@ -102,7 +102,7 @@ namespace GraphicalEditor.Models.MapObjectRelated
 
             MapObject examinationRoom2InBuilding1GroundLevel = new MapObject(
                    new Room(
-                       TypeOfMapObject.EXAMINATION_ROOM, DepartmentOfMapObject.CARDIOLOGY, FirstBuilding, 0, "Room 4"
+                       TypeOfMapObject.EXAMINATION_ROOM, DepartmentOfMapObject.CARDIOLOGY, FirstBuilding, 0
                    ),
                    new MapObjectMetrics(40, 240 - AllConstants.RECTANGLE_STROKE_THICKNESS, 100, 60 + AllConstants.RECTANGLE_STROKE_THICKNESS),
                    new MapObjectDoor(MapObjectDoorOrientation.RIGHT, 0, 0)
@@ -112,7 +112,7 @@ namespace GraphicalEditor.Models.MapObjectRelated
 
             MapObject waitingRoomBuilding1GroundLevel = new MapObject(
                   new Room(
-                       TypeOfMapObject.WAITING_ROOM, DepartmentOfMapObject.CARDIOLOGY, FirstBuilding, 0, "Waiting room 1"
+                       TypeOfMapObject.WAITING_ROOM, DepartmentOfMapObject.CARDIOLOGY, FirstBuilding, 0
                   ),
                   new MapObjectMetrics(185, 165, 140, 90),
                   new MapObjectDoor(MapObjectDoorOrientation.NONE)
@@ -122,7 +122,7 @@ namespace GraphicalEditor.Models.MapObjectRelated
 
             MapObject wcForManBuilding1GroundLevel = new MapObject(
                   new Room(
-                       TypeOfMapObject.WC, DepartmentOfMapObject.CARDIOLOGY, FirstBuilding, 0, "WC 1"
+                       TypeOfMapObject.WC, DepartmentOfMapObject.CARDIOLOGY, FirstBuilding, 0
                   ),
                   new MapObjectMetrics(370, 120 - AllConstants.RECTANGLE_STROKE_THICKNESS, 70, 55 + AllConstants.RECTANGLE_STROKE_THICKNESS),
                   new MapObjectDoor(MapObjectDoorOrientation.LEFT, 0, 0)
@@ -142,7 +142,7 @@ namespace GraphicalEditor.Models.MapObjectRelated
 
             MapObject examiantionRoom3InBuilding1GroundLevel = new MapObject(
                   new Room(
-                     TypeOfMapObject.EXAMINATION_ROOM, DepartmentOfMapObject.CARDIOLOGY, FirstBuilding, 0, "Room 5"
+                     TypeOfMapObject.EXAMINATION_ROOM, DepartmentOfMapObject.CARDIOLOGY, FirstBuilding, 0
                   ),
                   new MapObjectMetrics(370, 230 - AllConstants.RECTANGLE_STROKE_THICKNESS, 70, 70 + AllConstants.RECTANGLE_STROKE_THICKNESS),
                   new MapObjectDoor(MapObjectDoorOrientation.LEFT, 0, 0)
@@ -155,7 +155,7 @@ namespace GraphicalEditor.Models.MapObjectRelated
         {
             MapObject examinationRoom1InBuilding1FirstFloor = new MapObject(
                     new Room(
-                        TypeOfMapObject.EXAMINATION_ROOM, DepartmentOfMapObject.NEUROLOGY, FirstBuilding, 1,"Examiantion room 3"
+                        TypeOfMapObject.EXAMINATION_ROOM, DepartmentOfMapObject.NEUROLOGY, FirstBuilding, 1
                     ),
                     new MapObjectMetrics(40, 50, 145, 70),
                     new MapObjectDoor(MapObjectDoorOrientation.BOTTOM, 30, 0)
@@ -165,7 +165,7 @@ namespace GraphicalEditor.Models.MapObjectRelated
 
             MapObject wcForManBuilding1FirstFloor = new MapObject(
                  new Room(
-                     TypeOfMapObject.WC, DepartmentOfMapObject.NEUROLOGY, FirstBuilding, 1, "WC 1"
+                     TypeOfMapObject.WC, DepartmentOfMapObject.NEUROLOGY, FirstBuilding, 1
                  ),
                  new MapObjectMetrics(185 - AllConstants.RECTANGLE_STROKE_THICKNESS, 50, 55 + AllConstants.RECTANGLE_STROKE_THICKNESS, 70),
                  new MapObjectDoor(MapObjectDoorOrientation.BOTTOM, 0, 0)
@@ -175,7 +175,7 @@ namespace GraphicalEditor.Models.MapObjectRelated
 
             MapObject wcForWomanBuilding1FirstFloor = new MapObject(
                   new Room(
-                      TypeOfMapObject.WC, DepartmentOfMapObject.NEUROLOGY, FirstBuilding, 1, "WC 2"
+                      TypeOfMapObject.WC, DepartmentOfMapObject.NEUROLOGY, FirstBuilding, 1
                   ),
                   new MapObjectMetrics(240 - AllConstants.RECTANGLE_STROKE_THICKNESS, 50, 55 + AllConstants.RECTANGLE_STROKE_THICKNESS, 70),
                   new MapObjectDoor(MapObjectDoorOrientation.BOTTOM, 0, 0)
@@ -185,7 +185,7 @@ namespace GraphicalEditor.Models.MapObjectRelated
 
             MapObject examinationRoom2InBuilding1FirstFloor = new MapObject(
                   new Room(
-                      TypeOfMapObject.EXAMINATION_ROOM, DepartmentOfMapObject.NEUROLOGY, FirstBuilding, 1, "Room 4"
+                      TypeOfMapObject.EXAMINATION_ROOM, DepartmentOfMapObject.NEUROLOGY, FirstBuilding, 1
                   ),
                   new MapObjectMetrics(40, 120 - AllConstants.RECTANGLE_STROKE_THICKNESS, 75, 120 + AllConstants.RECTANGLE_STROKE_THICKNESS),
                   new MapObjectDoor(MapObjectDoorOrientation.RIGHT, 0, 0)
@@ -196,7 +196,7 @@ namespace GraphicalEditor.Models.MapObjectRelated
 
             MapObject examinationRoom3InBuilding1FirstFloor = new MapObject(
                    new Room(
-                       TypeOfMapObject.EXAMINATION_ROOM, DepartmentOfMapObject.NEUROLOGY, FirstBuilding, 1, "Room 4"
+                       TypeOfMapObject.EXAMINATION_ROOM, DepartmentOfMapObject.NEUROLOGY, FirstBuilding, 1
                    ),
                    new MapObjectMetrics(40, 240 - AllConstants.RECTANGLE_STROKE_THICKNESS, 120, 60 + AllConstants.RECTANGLE_STROKE_THICKNESS),
                    new MapObjectDoor(MapObjectDoorOrientation.RIGHT, 0, 0)
@@ -206,7 +206,7 @@ namespace GraphicalEditor.Models.MapObjectRelated
 
             MapObject operationRoom1InBuilding1FirstFloor = new MapObject(
                    new Room(
-                       TypeOfMapObject.OPERATION_ROOM, DepartmentOfMapObject.NEUROLOGY, FirstBuilding, 1, "Operation room 1"
+                       TypeOfMapObject.OPERATION_ROOM, DepartmentOfMapObject.NEUROLOGY, FirstBuilding, 1
                    ),
                    new MapObjectMetrics(295 - AllConstants.RECTANGLE_STROKE_THICKNESS, 50, 145 + AllConstants.RECTANGLE_STROKE_THICKNESS, 70),
                    new MapObjectDoor(MapObjectDoorOrientation.BOTTOM, -30, 0)
@@ -217,7 +217,7 @@ namespace GraphicalEditor.Models.MapObjectRelated
 
             MapObject operationRoom2InBuilding1FirstFloor = new MapObject(
                    new Room(
-                       TypeOfMapObject.OPERATION_ROOM, DepartmentOfMapObject.NEUROLOGY, FirstBuilding, 1, "Operation room 1"
+                       TypeOfMapObject.OPERATION_ROOM, DepartmentOfMapObject.NEUROLOGY, FirstBuilding, 1
                    ),
                    new MapObjectMetrics(365, 120 - AllConstants.RECTANGLE_STROKE_THICKNESS, 75, 120 + AllConstants.RECTANGLE_STROKE_THICKNESS),
                    new MapObjectDoor(MapObjectDoorOrientation.LEFT, 0, 0)
@@ -228,7 +228,7 @@ namespace GraphicalEditor.Models.MapObjectRelated
 
             MapObject operationRoom3InBuilding1FirstFloor = new MapObject(
                    new Room(
-                       TypeOfMapObject.OPERATION_ROOM, DepartmentOfMapObject.NEUROLOGY, FirstBuilding, 1, "Operation room 1"
+                       TypeOfMapObject.OPERATION_ROOM, DepartmentOfMapObject.NEUROLOGY, FirstBuilding, 1
                    ),
                    new MapObjectMetrics(320, 240 - AllConstants.RECTANGLE_STROKE_THICKNESS, 120, 60 + AllConstants.RECTANGLE_STROKE_THICKNESS),
                    new MapObjectDoor(MapObjectDoorOrientation.LEFT, 0, 0)
@@ -239,7 +239,7 @@ namespace GraphicalEditor.Models.MapObjectRelated
 
             MapObject waitingRoomBuilding1FirstFloor = new MapObject(
                  new Room(
-                     TypeOfMapObject.WAITING_ROOM, DepartmentOfMapObject.NEUROLOGY, FirstBuilding, 1, "Waiting room 1"
+                     TypeOfMapObject.WAITING_ROOM, DepartmentOfMapObject.NEUROLOGY, FirstBuilding, 1
                  ),
                  new MapObjectMetrics(165, 145, 150, 80),
                  new MapObjectDoor(MapObjectDoorOrientation.NONE)
@@ -253,7 +253,7 @@ namespace GraphicalEditor.Models.MapObjectRelated
         {
             MapObject wc1ForManBuilding2GroundLevel = new MapObject(
                            new Room(
-                               TypeOfMapObject.WC, DepartmentOfMapObject.PULMOLOGY, SecondBuilding, 0, "WC 3"
+                               TypeOfMapObject.WC, DepartmentOfMapObject.PULMOLOGY, SecondBuilding, 0
                            ),
                            new MapObjectMetrics(840, 50, 55, 70),
                            new MapObjectDoor(MapObjectDoorOrientation.BOTTOM, 0, 0)
@@ -263,7 +263,7 @@ namespace GraphicalEditor.Models.MapObjectRelated
 
             MapObject wc1ForWomanBuilding2GroundLevel = new MapObject(
                   new Room(
-                      TypeOfMapObject.WC, DepartmentOfMapObject.PULMOLOGY, SecondBuilding, 0, "WC 4"
+                      TypeOfMapObject.WC, DepartmentOfMapObject.PULMOLOGY, SecondBuilding, 0
                   ),
                   new MapObjectMetrics(895 - Constants.AllConstants.RECTANGLE_STROKE_THICKNESS, 50, 55, 70),
                   new MapObjectDoor(MapObjectDoorOrientation.BOTTOM, 0, 0)
@@ -273,7 +273,7 @@ namespace GraphicalEditor.Models.MapObjectRelated
 
             MapObject wc2ForManBuilding2GroundLevel = new MapObject(
                new Room(
-                   TypeOfMapObject.WC, DepartmentOfMapObject.PULMOLOGY, SecondBuilding, 0, "WC 5"
+                   TypeOfMapObject.WC, DepartmentOfMapObject.PULMOLOGY, SecondBuilding, 0
                ),
                new MapObjectMetrics(840, 592, 55, 70),
                new MapObjectDoor(MapObjectDoorOrientation.TOP, 0, 0)
@@ -283,7 +283,7 @@ namespace GraphicalEditor.Models.MapObjectRelated
 
             MapObject wc2ForWomanBuilding2GroundLevel = new MapObject(
                   new Room(
-                      TypeOfMapObject.WC, DepartmentOfMapObject.PULMOLOGY, SecondBuilding, 0, "WC 6"
+                      TypeOfMapObject.WC, DepartmentOfMapObject.PULMOLOGY, SecondBuilding, 0
                   ),
                   new MapObjectMetrics(895 - Constants.AllConstants.RECTANGLE_STROKE_THICKNESS, 592, 55, 70),
                   new MapObjectDoor(MapObjectDoorOrientation.TOP, 0, 0)
@@ -294,7 +294,7 @@ namespace GraphicalEditor.Models.MapObjectRelated
 
             MapObject waitingRoom1Building2GroundLevel = new MapObject(
                   new Room(
-                      TypeOfMapObject.WAITING_ROOM, DepartmentOfMapObject.PULMOLOGY, SecondBuilding, 0, "Waiting room 2"
+                      TypeOfMapObject.WAITING_ROOM, DepartmentOfMapObject.PULMOLOGY, SecondBuilding, 0
                   ),
                   new MapObjectMetrics(825, 140, 140, 150),
                   new MapObjectDoor(MapObjectDoorOrientation.NONE)
@@ -305,7 +305,7 @@ namespace GraphicalEditor.Models.MapObjectRelated
 
             MapObject waitingRoom2Building2GroundLevel = new MapObject(
                  new Room(
-                     TypeOfMapObject.WAITING_ROOM, DepartmentOfMapObject.PULMOLOGY, SecondBuilding, 0, "Waiting room 3"
+                     TypeOfMapObject.WAITING_ROOM, DepartmentOfMapObject.PULMOLOGY, SecondBuilding, 0
                  ),
                  new MapObjectMetrics(825, 415, 140, 150),
                  new MapObjectDoor(MapObjectDoorOrientation.NONE)
@@ -334,7 +334,7 @@ namespace GraphicalEditor.Models.MapObjectRelated
                 {
                     MapObject examiantionRoomInBuilding2GroundLevel = new MapObject(
                         new Room(
-                            TypeOfMapObject.EXAMINATION_ROOM, DepartmentOfMapObject.PULMOLOGY, SecondBuilding, 0, "Examination room " + i
+                            TypeOfMapObject.EXAMINATION_ROOM, DepartmentOfMapObject.PULMOLOGY, SecondBuilding, 0
                         ),
                         new MapObjectMetrics(startXOfDrawing, yOfObject, widthOfObject, heightOfObject),
                         new MapObjectDoor(MapObjectDoorOrientation.RIGHT, 0, 0)
@@ -364,7 +364,7 @@ namespace GraphicalEditor.Models.MapObjectRelated
                 {
                     MapObject operationRoomInBuilding2GroundLevel = new MapObject(
                         new Room(
-                            TypeOfMapObject.OPERATION_ROOM, DepartmentOfMapObject.PULMOLOGY, SecondBuilding, 0, "Operation Room " + i
+                            TypeOfMapObject.OPERATION_ROOM, DepartmentOfMapObject.PULMOLOGY, SecondBuilding, 0
                         ),
                         new MapObjectMetrics(startXOfDrawing, yOfObject, widthOfObject, heightOfObject),
                         new MapObjectDoor(MapObjectDoorOrientation.LEFT, 0, 0)
@@ -379,7 +379,7 @@ namespace GraphicalEditor.Models.MapObjectRelated
         {
             MapObject wc1ForManBuilding2FirstFloor = new MapObject(
                            new Room(
-                               TypeOfMapObject.WC, DepartmentOfMapObject.GENERAL_MEDICINE, SecondBuilding, 1, "WC 3"
+                               TypeOfMapObject.WC, DepartmentOfMapObject.GENERAL_MEDICINE, SecondBuilding, 1
                            ),
                            new MapObjectMetrics(840, 50, 55, 70),
                            new MapObjectDoor(MapObjectDoorOrientation.BOTTOM, 0, 0)
@@ -389,7 +389,7 @@ namespace GraphicalEditor.Models.MapObjectRelated
 
             MapObject wc1ForWomanBuilding2FirstFloor = new MapObject(
                   new Room(
-                      TypeOfMapObject.WC, DepartmentOfMapObject.GENERAL_MEDICINE, SecondBuilding, 1, "WC 4"
+                      TypeOfMapObject.WC, DepartmentOfMapObject.GENERAL_MEDICINE, SecondBuilding, 1
                   ),
                   new MapObjectMetrics(895 - Constants.AllConstants.RECTANGLE_STROKE_THICKNESS, 50, 55, 70),
                   new MapObjectDoor(MapObjectDoorOrientation.BOTTOM, 0, 0)
@@ -399,7 +399,7 @@ namespace GraphicalEditor.Models.MapObjectRelated
 
             MapObject wc2ForManBuilding2FirstFloor = new MapObject(
                new Room(
-                   TypeOfMapObject.WC, DepartmentOfMapObject.GENERAL_MEDICINE, SecondBuilding, 1, "WC 5"
+                   TypeOfMapObject.WC, DepartmentOfMapObject.GENERAL_MEDICINE, SecondBuilding, 1
                ),
                new MapObjectMetrics(840, 592, 55, 70),
                new MapObjectDoor(MapObjectDoorOrientation.TOP, 0, 0)
@@ -409,7 +409,7 @@ namespace GraphicalEditor.Models.MapObjectRelated
 
             MapObject wc2ForWomanBuilding2FirstFloor = new MapObject(
                   new Room(
-                      TypeOfMapObject.WC, DepartmentOfMapObject.GENERAL_MEDICINE, SecondBuilding, 1, "WC 6"
+                      TypeOfMapObject.WC, DepartmentOfMapObject.GENERAL_MEDICINE, SecondBuilding, 1
                   ),
                   new MapObjectMetrics(895 - Constants.AllConstants.RECTANGLE_STROKE_THICKNESS, 592, 55, 70),
                   new MapObjectDoor(MapObjectDoorOrientation.TOP, 0, 0)
@@ -420,7 +420,7 @@ namespace GraphicalEditor.Models.MapObjectRelated
 
             MapObject waitingRoom1Building2FirstFloor = new MapObject(
                   new Room(
-                      TypeOfMapObject.WAITING_ROOM, DepartmentOfMapObject.GENERAL_MEDICINE, SecondBuilding, 1, "Waiting room 2"
+                      TypeOfMapObject.WAITING_ROOM, DepartmentOfMapObject.GENERAL_MEDICINE, SecondBuilding, 1
                   ),
                   new MapObjectMetrics(825, 140, 140, 150),
                   new MapObjectDoor(MapObjectDoorOrientation.NONE)
@@ -431,7 +431,7 @@ namespace GraphicalEditor.Models.MapObjectRelated
 
             MapObject waitingRoom2Building2FirstFloor = new MapObject(
                  new Room(
-                     TypeOfMapObject.WAITING_ROOM, DepartmentOfMapObject.GENERAL_MEDICINE, SecondBuilding, 1, "Waiting room 3"
+                     TypeOfMapObject.WAITING_ROOM, DepartmentOfMapObject.GENERAL_MEDICINE, SecondBuilding, 1
                  ),
                  new MapObjectMetrics(825, 410, 120, 150),
                  new MapObjectDoor(MapObjectDoorOrientation.NONE)
@@ -451,7 +451,7 @@ namespace GraphicalEditor.Models.MapObjectRelated
 
                 MapObject hospitalizationRoomInBuilding2FirstFloor = new MapObject(
                new Room(
-                   TypeOfMapObject.HOSPITALIZATION_ROOM, DepartmentOfMapObject.GENERAL_MEDICINE, SecondBuilding, 1, "Examination room " + i
+                   TypeOfMapObject.HOSPITALIZATION_ROOM, DepartmentOfMapObject.GENERAL_MEDICINE, SecondBuilding, 1
                ),
                new MapObjectMetrics(startXOfDrawing, yOfObject, widthOfObject, heightOfObject),
                new MapObjectDoor(MapObjectDoorOrientation.RIGHT, 0, 0)
@@ -472,7 +472,7 @@ namespace GraphicalEditor.Models.MapObjectRelated
 
                 MapObject hospitalizationInBuilding2FirstFloor = new MapObject(
                new Room(
-                   TypeOfMapObject.HOSPITALIZATION_ROOM, DepartmentOfMapObject.GENERAL_MEDICINE, SecondBuilding, 1, "Operation Room " + i
+                   TypeOfMapObject.HOSPITALIZATION_ROOM, DepartmentOfMapObject.GENERAL_MEDICINE, SecondBuilding, 1
                ),
                new MapObjectMetrics(startXOfDrawing, yOfObject, widthOfObject, heightOfObject),
                new MapObjectDoor(MapObjectDoorOrientation.LEFT, 0, 0)
@@ -492,7 +492,7 @@ namespace GraphicalEditor.Models.MapObjectRelated
 
                 MapObject examinationInBuilding2FirstFloor = new MapObject(
                new Room(
-                   TypeOfMapObject.HOSPITALIZATION_ROOM, DepartmentOfMapObject.GENERAL_MEDICINE, SecondBuilding, 1, "Examination room " + i
+                   TypeOfMapObject.HOSPITALIZATION_ROOM, DepartmentOfMapObject.GENERAL_MEDICINE, SecondBuilding, 1
                ),
                new MapObjectMetrics(startXOfDrawing, yOfObject, widthOfObject, heightOfObject),
                new MapObjectDoor(MapObjectDoorOrientation.RIGHT, 0, 0)
@@ -504,7 +504,7 @@ namespace GraphicalEditor.Models.MapObjectRelated
 
             MapObject operationRoom1InBuilding2FirstFloor = new MapObject(
                new Room(
-                   TypeOfMapObject.OPERATION_ROOM, DepartmentOfMapObject.GENERAL_MEDICINE, SecondBuilding, 1, "Examination room 1"
+                   TypeOfMapObject.OPERATION_ROOM, DepartmentOfMapObject.GENERAL_MEDICINE, SecondBuilding, 1
                ),
                new MapObjectMetrics(800 + 190, 320 + 78, 70, 100),
                new MapObjectDoor(MapObjectDoorOrientation.LEFT, 0, 0)
@@ -514,7 +514,7 @@ namespace GraphicalEditor.Models.MapObjectRelated
 
             MapObject operationRoom2InBuilding2FirstFloor = new MapObject(
                new Room(
-                   TypeOfMapObject.OPERATION_ROOM, DepartmentOfMapObject.GENERAL_MEDICINE, SecondBuilding, 1, "Examination room 1"
+                   TypeOfMapObject.OPERATION_ROOM, DepartmentOfMapObject.GENERAL_MEDICINE, SecondBuilding, 1
                ),
                new MapObjectMetrics(800 + 170, 420 + 78 - AllConstants.RECTANGLE_STROKE_THICKNESS, 90, 170 - AllConstants.RECTANGLE_STROKE_THICKNESS),
                new MapObjectDoor(MapObjectDoorOrientation.LEFT, 0, 0)
@@ -533,7 +533,7 @@ namespace GraphicalEditor.Models.MapObjectRelated
                 double xOfObject = i == 0 ? startXOfDrawing : startXOfDrawing + widthOfObject * i - i * Constants.AllConstants.RECTANGLE_STROKE_THICKNESS;
 
                 MapObject parking = new MapObject(
-                    new Parking(),
+                    new Parking("Parking se nalazi ispred Zgrade 1, okruzen objektima kompleksa bolnice."),
                     new MapObjectMetrics(xOfObject, 440, widthOfObject, 60),
                     new MapObjectDoor(MapObjectDoorOrientation.NONE)
                 );
@@ -549,7 +549,7 @@ namespace GraphicalEditor.Models.MapObjectRelated
                 double xOfObject = i == 0 ? startXOfDrawing : startXOfDrawing + widthOfParkingPlace * i - i * Constants.AllConstants.RECTANGLE_STROKE_THICKNESS;
 
                 MapObject parking = new MapObject(
-                    new Parking(),
+                    new Parking("Parking se nalazi ispred Zgrade 1, okruzen objektima kompleksa bolnice."),
                     new MapObjectMetrics(xOfObject, 565, widthOfParkingPlace, 60),
                     new MapObjectDoor(MapObjectDoorOrientation.NONE)
                 );

--- a/HealthcareSystemFrontends/ManagerFrontend/App.xaml
+++ b/HealthcareSystemFrontends/ManagerFrontend/App.xaml
@@ -1,15 +1,123 @@
-﻿<Application x:Class="Clinic_Health.App"
-             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:local="clr-namespace:Clinic_Health" xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
-             StartupUri="MainWindow.xaml">
+﻿<Application
+    x:Class="Clinic_Health.App"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="clr-namespace:Clinic_Health"
+    xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
+    StartupUri="MainWindow.xaml">
     <Application.Resources>
-       
+
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
-                <materialDesign:BundledTheme BaseTheme="Light" PrimaryColor="LightGreen" SecondaryColor="Green" />
+                <materialDesign:BundledTheme
+                    BaseTheme="Light"
+                    PrimaryColor="LightGreen"
+                    SecondaryColor="Green" />
                 <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Defaults.xaml" />
             </ResourceDictionary.MergedDictionaries>
-        </ResourceDictionary> 
+
+
+            <!--  GRAPHICAL EDITOR STYLES  -->
+
+            <!--  SIDE PANEL DATA GRID STYLE  -->
+            <!--  DataGrid  -->
+            <Style
+                x:Key="SidePanelDataGrid"
+                BasedOn="{StaticResource MaterialDesignDataGrid}"
+                TargetType="DataGrid">
+                <Setter Property="AutoGenerateColumns" Value="False" />
+                <Setter Property="CanUserAddRows" Value="False" />
+                <Setter Property="CanUserDeleteRows" Value="False" />
+                <Setter Property="CanUserReorderColumns" Value="False" />
+                <Setter Property="CanUserResizeColumns" Value="False" />
+                <Setter Property="CanUserResizeRows" Value="False" />
+                <Setter Property="ColumnHeaderHeight" Value="30" />
+                <Setter Property="HeadersVisibility" Value="Column" />
+                <Setter Property="IsReadOnly" Value="True" />
+                <Setter Property="SelectionMode" Value="Single" />
+
+                <Setter Property="VerticalScrollBarVisibility" Value="Visible" />
+                <Setter Property="ScrollViewer.CanContentScroll" Value="True" />
+
+
+                <Setter Property="HorizontalGridLinesBrush" Value="LightPink" />
+                <Setter Property="VerticalGridLinesBrush" Value="Transparent" />
+
+
+                <Style.Resources>
+                    <!--  DataGridColumnHeader  -->
+                    <Style TargetType="DataGridColumnHeader">
+                        <Setter Property="HorizontalContentAlignment" Value="Center" />
+                        <Setter Property="VerticalContentAlignment" Value="Center" />
+
+                        <Setter Property="FontFamily" Value="Roboto" />
+                        <Setter Property="FontSize" Value="16" />
+
+
+                        <Setter Property="Background" Value="MediumPurple" />
+                        <Setter Property="Foreground" Value="White" />
+                    </Style>
+
+
+                    <!--  DataGridRow  -->
+                    <Style TargetType="DataGridRow">
+                        <Setter Property="Height" Value="40" />
+                        <Setter Property="FontSize" Value="16" />
+
+
+                        <Style.Resources>
+                            <SolidColorBrush x:Key="{x:Static SystemColors.HighlightBrushKey}" Color="Lavender" />
+                            <SolidColorBrush x:Key="{x:Static SystemColors.ControlBrushKey}" Color="MediumPurple" />
+                            <SolidColorBrush x:Key="{x:Static SystemColors.HighlightTextBrushKey}" Color="Black" />
+                            <SolidColorBrush x:Key="{x:Static SystemColors.ControlTextBrushKey}" Color="Black" />
+                        </Style.Resources>
+                    </Style>
+
+                    <!--  DataGridCell  -->
+                    <Style TargetType="DataGridCell">
+                        <Setter Property="BorderThickness" Value="0" />
+                        <Setter Property="FocusVisualStyle" Value="{x:Null}" />
+                        <Style.Resources>
+                            <Style TargetType="ContentPresenter">
+                                <Setter Property="HorizontalAlignment" Value="Center" />
+                                <Setter Property="VerticalAlignment" Value="Center" />
+                            </Style>
+                        </Style.Resources>
+                    </Style>
+                </Style.Resources>
+            </Style>
+
+
+            <!--  SIDE PANEL DATA GRID Row  -->
+            <Style
+                x:Key="SidePanelDataGridRow"
+                BasedOn="{StaticResource MaterialDesignDataGridRow}"
+                TargetType="DataGridRow">
+                <Setter Property="Height" Value="40" />
+                <Setter Property="FontSize" Value="16" />
+
+
+                <Style.Resources>
+                    <SolidColorBrush x:Key="{x:Static SystemColors.HighlightBrushKey}" Color="Lavender" />
+                    <SolidColorBrush x:Key="{x:Static SystemColors.ControlBrushKey}" Color="MediumPurple" />
+                    <SolidColorBrush x:Key="{x:Static SystemColors.HighlightTextBrushKey}" Color="Black" />
+                    <SolidColorBrush x:Key="{x:Static SystemColors.ControlTextBrushKey}" Color="Black" />
+                </Style.Resources>
+            </Style>
+
+
+            <!--  DATA GRID BUTTON THAT IS VISIBLE ONLY ON ROW HOVER  -->
+            <Style
+                x:Key="DataGridButtonVisibleOnRowHover"
+                BasedOn="{StaticResource MaterialDesignRaisedButton}"
+                TargetType="Button">
+                <Setter Property="Visibility" Value="Collapsed" />
+                <Style.Triggers>
+                    <DataTrigger Binding="{Binding RelativeSource={RelativeSource AncestorType={x:Type DataGridRow}}, Path=IsMouseOver}" Value="True">
+                        <Setter Property="Visibility" Value="Visible" />
+                    </DataTrigger>
+                </Style.Triggers>
+            </Style>
+        </ResourceDictionary>
     </Application.Resources>
 </Application>

--- a/HealthcareSystemFrontends/PatientFrontend/App.xaml
+++ b/HealthcareSystemFrontends/PatientFrontend/App.xaml
@@ -1,8 +1,9 @@
-﻿<Application x:Class="PatientFrontend.App"
-             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:local="clr-namespace:ZdravoKorporacija"
-             StartupUri="View/MainWindow.xaml">
+﻿<Application
+    x:Class="PatientFrontend.App"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="clr-namespace:ZdravoKorporacija"
+    StartupUri="View/MainWindow.xaml">
     <Application.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
@@ -14,109 +15,132 @@
 
 
             <Style TargetType="local:MainWindow">
-                <Setter Property="FontSize" Value="20"/>
-                <Setter Property="ResizeMode" Value="NoResize"/>
+                <Setter Property="FontSize" Value="20" />
+                <Setter Property="ResizeMode" Value="NoResize" />
             </Style>
 
             <Style TargetType="local:RegistrationWindow">
-                <Setter Property="FontSize" Value="20"/>
-                <Setter Property="ResizeMode" Value="NoResize"/>
+                <Setter Property="FontSize" Value="20" />
+                <Setter Property="ResizeMode" Value="NoResize" />
             </Style>
 
             <Style TargetType="Label">
-                <Setter Property="FontSize" Value="20"/>
-                <Setter Property="Foreground" Value="DarkBlue"/>
-                <Setter Property="HorizontalContentAlignment" Value="Right"/>
-                <Setter Property="Width" Value="350"/>
-                <Setter Property="Margin" Value="5"/>
-                <Setter Property="Grid.ColumnSpan" Value="2"/>
+                <Setter Property="FontSize" Value="20" />
+                <Setter Property="Foreground" Value="DarkBlue" />
+                <Setter Property="HorizontalContentAlignment" Value="Right" />
+                <Setter Property="Width" Value="350" />
+                <Setter Property="Margin" Value="5" />
+                <Setter Property="Grid.ColumnSpan" Value="2" />
             </Style>
 
             <Style x:Key="labeleStyle" TargetType="Label">
-                <Setter Property="FontSize" Value="20"/>
-                <Setter Property="Foreground" Value="DarkBlue"/>
-                <Setter Property="HorizontalContentAlignment" Value="Right"/>
-                <Setter Property="Padding" Value="160,0,0,0"/>
-                <Setter Property="Width" Value="350"/>
-                <Setter Property="Margin" Value="5"/>
-                <Setter Property="Grid.ColumnSpan" Value="2"/>
+                <Setter Property="FontSize" Value="20" />
+                <Setter Property="Foreground" Value="DarkBlue" />
+                <Setter Property="HorizontalContentAlignment" Value="Right" />
+                <Setter Property="Padding" Value="160,0,0,0" />
+                <Setter Property="Width" Value="350" />
+                <Setter Property="Margin" Value="5" />
+                <Setter Property="Grid.ColumnSpan" Value="2" />
             </Style>
 
             <Style x:Key="labeleAppointmentStyle" TargetType="Label">
-                <Setter Property="FontSize" Value="20"/>
-                <Setter Property="Foreground" Value="DarkBlue"/>
-                <Setter Property="HorizontalContentAlignment" Value="Right"/>
-                <Setter Property="Width" Value="280"/>
-                <Setter Property="Margin" Value="5"/>
-                <Setter Property="Grid.ColumnSpan" Value="2"/>
+                <Setter Property="FontSize" Value="20" />
+                <Setter Property="Foreground" Value="DarkBlue" />
+                <Setter Property="HorizontalContentAlignment" Value="Right" />
+                <Setter Property="Width" Value="280" />
+                <Setter Property="Margin" Value="5" />
+                <Setter Property="Grid.ColumnSpan" Value="2" />
             </Style>
 
             <Style x:Key="textBoxAppointmentStyle" TargetType="TextBox">
-                <Setter Property="Foreground" Value="DarkBlue"/>
-                <Setter Property="Background" Value="AliceBlue"/>
-                <Setter Property="FontSize" Value="20"/>
-                <Setter Property="Height" Value="35"/>
-                <Setter Property="Width" Value="370"/>
-                <Setter Property="HorizontalAlignment" Value="Center"/>
-                <Setter Property="Margin" Value="5"/>
-                <Setter Property="Grid.ColumnSpan" Value="3"/>
+                <Setter Property="Foreground" Value="DarkBlue" />
+                <Setter Property="Background" Value="AliceBlue" />
+                <Setter Property="FontSize" Value="20" />
+                <Setter Property="Height" Value="35" />
+                <Setter Property="Width" Value="370" />
+                <Setter Property="HorizontalAlignment" Value="Center" />
+                <Setter Property="Margin" Value="5" />
+                <Setter Property="Grid.ColumnSpan" Value="3" />
             </Style>
 
             <Style x:Key="groupBoxStyle" TargetType="GroupBox">
-                <Setter Property="Foreground" Value="DarkBlue"/>
-                <Setter Property="Background" Value="AliceBlue"/>
-                <Setter Property="FontSize" Value="20"/>
-                <Setter Property="Width" Value="370"/>
-                <Setter Property="HorizontalAlignment" Value="Center"/>
-                <Setter Property="Margin" Value="5"/>
-                <Setter Property="Grid.ColumnSpan" Value="3"/>
+                <Setter Property="Foreground" Value="DarkBlue" />
+                <Setter Property="Background" Value="AliceBlue" />
+                <Setter Property="FontSize" Value="20" />
+                <Setter Property="Width" Value="370" />
+                <Setter Property="HorizontalAlignment" Value="Center" />
+                <Setter Property="Margin" Value="5" />
+                <Setter Property="Grid.ColumnSpan" Value="3" />
             </Style>
 
             <Style x:Key="buttonAppointmentStyle" TargetType="Button">
-                <Setter Property="FontWeight" Value="Normal"/>
-                <Setter Property="FontSize" Value="20"/>
-                <Setter Property="Foreground" Value="DarkBlue"/>
-                <Setter Property="Background" Value="AliceBlue"/>
-                <Setter Property="Grid.ColumnSpan" Value="3"/>
-                <Setter Property="HorizontalAlignment" Value="Center"/>
-                <Setter Property="Margin" Value="5"/>
-                <Setter Property="Width" Value="370"/>
-                <Setter Property="Height" Value="50"/>
-                <Setter Property="Cursor" Value="Hand"/>
+                <Setter Property="FontWeight" Value="Normal" />
+                <Setter Property="FontSize" Value="20" />
+                <Setter Property="Foreground" Value="DarkBlue" />
+                <Setter Property="Background" Value="AliceBlue" />
+                <Setter Property="Grid.ColumnSpan" Value="3" />
+                <Setter Property="HorizontalAlignment" Value="Center" />
+                <Setter Property="Margin" Value="5" />
+                <Setter Property="Width" Value="370" />
+                <Setter Property="Height" Value="50" />
+                <Setter Property="Cursor" Value="Hand" />
             </Style>
 
             <Style x:Key="comboBoxAppointmentStyle" TargetType="ComboBox">
-                <Setter Property="Foreground" Value="DarkBlue"/>
-                <Setter Property="Background" Value="AliceBlue"/>
-                <Setter Property="FontSize" Value="20"/>
-                <Setter Property="Height" Value="35"/>
-                <Setter Property="Width" Value="370"/>
-                <Setter Property="Margin" Value="5"/>
-                <Setter Property="Grid.ColumnSpan" Value="3"/>
+                <Setter Property="Foreground" Value="DarkBlue" />
+                <Setter Property="Background" Value="AliceBlue" />
+                <Setter Property="FontSize" Value="20" />
+                <Setter Property="Height" Value="35" />
+                <Setter Property="Width" Value="370" />
+                <Setter Property="Margin" Value="5" />
+                <Setter Property="Grid.ColumnSpan" Value="3" />
             </Style>
 
             <Style TargetType="TextBox">
-                <Setter Property="Foreground" Value="DarkBlue"/>
-                <Setter Property="Background" Value="AliceBlue"/>
-                <Setter Property="HorizontalAlignment" Value="Center"/>
-                <Setter Property="VerticalAlignment" Value="Center"/>
-                <Setter Property="TextAlignment" Value ="Left"/>
-                <Setter Property="Height" Value="35"/>
-                <Setter Property="Width" Value="350"/>
-                <Setter Property="FontSize" Value="20"/>
-                <Setter Property="Margin" Value="5"/>
-                <Setter Property="Grid.ColumnSpan" Value="2"/>
+                <Setter Property="Foreground" Value="DarkBlue" />
+                <Setter Property="Background" Value="AliceBlue" />
+                <Setter Property="HorizontalAlignment" Value="Center" />
+                <Setter Property="VerticalAlignment" Value="Center" />
+                <Setter Property="TextAlignment" Value="Left" />
+                <Setter Property="Height" Value="35" />
+                <Setter Property="Width" Value="350" />
+                <Setter Property="FontSize" Value="20" />
+                <Setter Property="Margin" Value="5" />
+                <Setter Property="Grid.ColumnSpan" Value="2" />
                 <Setter Property="Validation.ErrorTemplate">
                     <Setter.Value>
                         <ControlTemplate>
                             <DockPanel>
-                                <Grid DockPanel.Dock="Right" Width="16" Height="16" VerticalAlignment="Center" Margin="3 0 0 0">
-                                    <Ellipse Width="16" Height="16" Fill="Red"/>
-                                    <Ellipse Width="3" Height="8" VerticalAlignment="Top" HorizontalAlignment="Center" Margin="0 2 0 0" Fill="White"/>
-                                    <Ellipse Width="2" Height="2" VerticalAlignment="Bottom" HorizontalAlignment="Center" Margin="0 0 0 2" Fill="White"/>
+                                <Grid
+                                    Width="16"
+                                    Height="16"
+                                    Margin="3,0,0,0"
+                                    VerticalAlignment="Center"
+                                    DockPanel.Dock="Right">
+                                    <Ellipse
+                                        Width="16"
+                                        Height="16"
+                                        Fill="Red" />
+                                    <Ellipse
+                                        Width="3"
+                                        Height="8"
+                                        Margin="0,2,0,0"
+                                        HorizontalAlignment="Center"
+                                        VerticalAlignment="Top"
+                                        Fill="White" />
+                                    <Ellipse
+                                        Width="2"
+                                        Height="2"
+                                        Margin="0,0,0,2"
+                                        HorizontalAlignment="Center"
+                                        VerticalAlignment="Bottom"
+                                        Fill="White" />
                                 </Grid>
-                                <Border BorderBrush="Red" BorderThickness="2" CornerRadius="2">
-                                    <AdornedElementPlaceholder/>
+                                <Border
+                                    BorderBrush="Red"
+                                    BorderThickness="2"
+                                    CornerRadius="2">
+                                    <AdornedElementPlaceholder />
                                 </Border>
                             </DockPanel>
                         </ControlTemplate>
@@ -124,124 +148,228 @@
                 </Setter>
                 <Style.Triggers>
                     <Trigger Property="Validation.HasError" Value="true">
-                        <Setter Property="ToolTip" Value="{Binding RelativeSource={x:Static RelativeSource.Self}, Path=(Validation.Errors)[0].ErrorContent}"/>
+                        <Setter Property="ToolTip" Value="{Binding RelativeSource={x:Static RelativeSource.Self}, Path=(Validation.Errors)[0].ErrorContent}" />
                     </Trigger>
                 </Style.Triggers>
             </Style>
 
             <Style x:Key="naviTextBlock" TargetType="TextBlock">
-                <Setter Property="Foreground" Value="DarkBlue"/>
-                <Setter Property="HorizontalAlignment" Value="Center"/>
-                <Setter Property="TextAlignment" Value ="Center"/>
-                <Setter Property="FontWeight" Value="Normal"/>
-                <Setter Property="FontSize" Value="18"/>
+                <Setter Property="Foreground" Value="DarkBlue" />
+                <Setter Property="HorizontalAlignment" Value="Center" />
+                <Setter Property="TextAlignment" Value="Center" />
+                <Setter Property="FontWeight" Value="Normal" />
+                <Setter Property="FontSize" Value="18" />
             </Style>
 
             <Style TargetType="PasswordBox">
-                <Setter Property="Foreground" Value="DarkBlue"/>
-                <Setter Property="Background" Value="AliceBlue"/>
-                <Setter Property="VerticalAlignment" Value="Center"/>
-                <Setter Property="HorizontalAlignment" Value="Center"/>
-                <Setter Property="FontSize" Value="18"/>
-                <Setter Property="Grid.ColumnSpan" Value="2"/>
-                <Setter Property="Height" Value="35"/>
-                <Setter Property="Width" Value="350"/>
+                <Setter Property="Foreground" Value="DarkBlue" />
+                <Setter Property="Background" Value="AliceBlue" />
+                <Setter Property="VerticalAlignment" Value="Center" />
+                <Setter Property="HorizontalAlignment" Value="Center" />
+                <Setter Property="FontSize" Value="18" />
+                <Setter Property="Grid.ColumnSpan" Value="2" />
+                <Setter Property="Height" Value="35" />
+                <Setter Property="Width" Value="350" />
             </Style>
 
             <Style TargetType="RadioButton">
-                <Setter Property="Foreground" Value="DarkBlue"/>
-                <Setter Property="Background" Value="AliceBlue"/>
-                <Setter Property="HorizontalAlignment" Value="Left"/>
-                <Setter Property="Grid.ColumnSpan" Value="2"/>
-                <Setter Property="Width" Value="100"/>
-                <Setter Property="Margin" Value="2"/>
-                <Setter Property="FontSize" Value="18"/>
+                <Setter Property="Foreground" Value="DarkBlue" />
+                <Setter Property="Background" Value="AliceBlue" />
+                <Setter Property="HorizontalAlignment" Value="Left" />
+                <Setter Property="Grid.ColumnSpan" Value="2" />
+                <Setter Property="Width" Value="100" />
+                <Setter Property="Margin" Value="2" />
+                <Setter Property="FontSize" Value="18" />
             </Style>
 
             <Style TargetType="Button">
-                <Setter Property="FontWeight" Value="Normal"/>
-                <Setter Property="FontSize" Value="20"/>
-                <Setter Property="Foreground" Value="DarkBlue"/>
-                <Setter Property="Background" Value="AliceBlue"/>
-                <Setter Property="HorizontalAlignment" Value="Center"/>
-                <Setter Property="Cursor" Value="Hand"/>
+                <Setter Property="FontWeight" Value="Normal" />
+                <Setter Property="FontSize" Value="20" />
+                <Setter Property="Foreground" Value="DarkBlue" />
+                <Setter Property="Background" Value="AliceBlue" />
+                <Setter Property="HorizontalAlignment" Value="Center" />
+                <Setter Property="Cursor" Value="Hand" />
             </Style>
 
             <Style x:Key="homePageButton" TargetType="Button">
-                <Setter Property="FontWeight" Value="Normal"/>
-                <Setter Property="FontSize" Value="20"/>
-                <Setter Property="Foreground" Value="DarkBlue"/>
-                <Setter Property="Background" Value="AliceBlue"/>
-                <Setter Property="Grid.ColumnSpan" Value="3"/>
-                <Setter Property="Grid.RowSpan" Value="2"/>
-                <Setter Property="Margin" Value="10"/>
-                <Setter Property="Width" Value="370"/>
-                <Setter Property="Height" Value="60"/>
-                <Setter Property="Cursor" Value="Hand"/>
+                <Setter Property="FontWeight" Value="Normal" />
+                <Setter Property="FontSize" Value="20" />
+                <Setter Property="Foreground" Value="DarkBlue" />
+                <Setter Property="Background" Value="AliceBlue" />
+                <Setter Property="Grid.ColumnSpan" Value="3" />
+                <Setter Property="Grid.RowSpan" Value="2" />
+                <Setter Property="Margin" Value="10" />
+                <Setter Property="Width" Value="370" />
+                <Setter Property="Height" Value="60" />
+                <Setter Property="Cursor" Value="Hand" />
             </Style>
 
             <Style TargetType="DataGrid">
-                <Setter Property="CanUserResizeColumns" Value="False"/>
-                <Setter Property="CanUserAddRows" Value="False"/>
-                <Setter Property="CanUserAddRows" Value="False"/>
-                <Setter Property="CanUserReorderColumns" Value="False"/>
-                <Setter Property="HorizontalAlignment" Value="Center"/>
-                <Setter Property="AutoGenerateColumns" Value="False"/>
-                <Setter Property="IsReadOnly" Value="True"/>
-                <Setter Property="SelectionMode" Value="Single"/>
-                <Setter Property="Foreground" Value="DarkBlue"/>
-                <Setter Property="FontSize" Value="14"/>
-                <Setter Property="HorizontalContentAlignment" Value="Stretch"/>
-                <Setter Property="RowHeight" Value="25"/>
+                <Setter Property="CanUserResizeColumns" Value="False" />
+                <Setter Property="CanUserAddRows" Value="False" />
+                <Setter Property="CanUserAddRows" Value="False" />
+                <Setter Property="CanUserReorderColumns" Value="False" />
+                <Setter Property="HorizontalAlignment" Value="Center" />
+                <Setter Property="AutoGenerateColumns" Value="False" />
+                <Setter Property="IsReadOnly" Value="True" />
+                <Setter Property="SelectionMode" Value="Single" />
+                <Setter Property="Foreground" Value="DarkBlue" />
+                <Setter Property="FontSize" Value="14" />
+                <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+                <Setter Property="RowHeight" Value="25" />
             </Style>
 
             <Style TargetType="DataGridColumnHeader">
-                <Setter Property="HorizontalContentAlignment" Value="Center"/>
-                <Setter Property="Foreground" Value="DarkBlue"/>
-                <Setter Property="FontSize" Value="16"/>
+                <Setter Property="HorizontalContentAlignment" Value="Center" />
+                <Setter Property="Foreground" Value="DarkBlue" />
+                <Setter Property="FontSize" Value="16" />
             </Style>
 
             <Style x:Key="DataGridCellCentered" TargetType="DataGridCell">
                 <Setter Property="TextBlock.TextAlignment" Value="Center" />
-                <Setter Property="Foreground" Value="DarkBlue"/>
-                <Setter Property="FontSize" Value="16"/>
+                <Setter Property="Foreground" Value="DarkBlue" />
+                <Setter Property="FontSize" Value="16" />
             </Style>
 
             <Style x:Key="dataPickerStyle" TargetType="DatePicker">
-                <Setter Property="Foreground" Value="DarkBlue"/>
-                <Setter Property="Background" Value="AliceBlue"/>
-                <Setter Property="FontSize" Value="20"/>
-                <Setter Property="Height" Value="35"/>
-                <Setter Property="Width" Value="370"/>
-                <Setter Property="HorizontalAlignment" Value="Center"/>
-                <Setter Property="FirstDayOfWeek" Value="Monday"/>
-                <Setter Property="Margin" Value="5"/>
-                <Setter Property="Grid.ColumnSpan" Value="3"/>
-                <Setter Property="IsHitTestVisible" Value="True"/>
+                <Setter Property="Foreground" Value="DarkBlue" />
+                <Setter Property="Background" Value="AliceBlue" />
+                <Setter Property="FontSize" Value="20" />
+                <Setter Property="Height" Value="35" />
+                <Setter Property="Width" Value="370" />
+                <Setter Property="HorizontalAlignment" Value="Center" />
+                <Setter Property="FirstDayOfWeek" Value="Monday" />
+                <Setter Property="Margin" Value="5" />
+                <Setter Property="Grid.ColumnSpan" Value="3" />
+                <Setter Property="IsHitTestVisible" Value="True" />
             </Style>
 
             <Style x:Key="dataPickerRegistration" TargetType="DatePicker">
-                 <Setter Property="Foreground" Value="DarkBlue"/>
-                 <Setter Property="Background" Value="AliceBlue"/>
-                 <Setter Property="HorizontalAlignment" Value="Center"/>
-                 <Setter Property="VerticalAlignment" Value="Center"/>
-                 <Setter Property="Height" Value="35"/>
-                 <Setter Property="Width" Value="350"/>
-                 <Setter Property="FontSize" Value="20"/>
-                 <Setter Property="Margin" Value="5"/>
-                 <Setter Property="Grid.ColumnSpan" Value="2"/>
-                 <Setter Property="FontSize" Value="20"/>
-                 <Setter Property="HorizontalAlignment" Value="Center"/>
-                 <Setter Property="FirstDayOfWeek" Value="Monday"/>
-                 <Setter Property="IsHitTestVisible" Value="True"/>
+                <Setter Property="Foreground" Value="DarkBlue" />
+                <Setter Property="Background" Value="AliceBlue" />
+                <Setter Property="HorizontalAlignment" Value="Center" />
+                <Setter Property="VerticalAlignment" Value="Center" />
+                <Setter Property="Height" Value="35" />
+                <Setter Property="Width" Value="350" />
+                <Setter Property="FontSize" Value="20" />
+                <Setter Property="Margin" Value="5" />
+                <Setter Property="Grid.ColumnSpan" Value="2" />
+                <Setter Property="FontSize" Value="20" />
+                <Setter Property="HorizontalAlignment" Value="Center" />
+                <Setter Property="FirstDayOfWeek" Value="Monday" />
+                <Setter Property="IsHitTestVisible" Value="True" />
             </Style>
 
-            <Style x:Key="comboBoxItem"  TargetType="ComboBoxItem">
-                  <Setter Property="Foreground" Value="DarkBlue"/>
-                  <Setter Property="Background" Value="AliceBlue"/>
-                  <Setter Property="SnapsToDevicePixels" Value="True"/>
-                  <Setter Property="OverridesDefaultStyle" Value="True"/>
-                  <Setter Property="FontSize" Value="20"/>
+            <Style x:Key="comboBoxItem" TargetType="ComboBoxItem">
+                <Setter Property="Foreground" Value="DarkBlue" />
+                <Setter Property="Background" Value="AliceBlue" />
+                <Setter Property="SnapsToDevicePixels" Value="True" />
+                <Setter Property="OverridesDefaultStyle" Value="True" />
+                <Setter Property="FontSize" Value="20" />
+            </Style>
+
+
+
+            <!--  GRAPHICAL EDITOR STYLES  -->
+
+            <!--  SIDE PANEL DATA GRID STYLE  -->
+            <!--  DataGrid  -->
+            <Style
+                x:Key="SidePanelDataGrid"
+                BasedOn="{StaticResource MaterialDesignDataGrid}"
+                TargetType="DataGrid">
+                <Setter Property="AutoGenerateColumns" Value="False" />
+                <Setter Property="CanUserAddRows" Value="False" />
+                <Setter Property="CanUserDeleteRows" Value="False" />
+                <Setter Property="CanUserReorderColumns" Value="False" />
+                <Setter Property="CanUserResizeColumns" Value="False" />
+                <Setter Property="CanUserResizeRows" Value="False" />
+                <Setter Property="ColumnHeaderHeight" Value="30" />
+                <Setter Property="HeadersVisibility" Value="Column" />
+                <Setter Property="IsReadOnly" Value="True" />
+                <Setter Property="SelectionMode" Value="Single" />
+
+                <Setter Property="VerticalScrollBarVisibility" Value="Visible" />
+                <Setter Property="ScrollViewer.CanContentScroll" Value="True" />
+
+
+                <Setter Property="HorizontalGridLinesBrush" Value="LightPink" />
+                <Setter Property="VerticalGridLinesBrush" Value="Transparent" />
+
+
+                <Style.Resources>
+                    <!--  DataGridColumnHeader  -->
+                    <Style TargetType="DataGridColumnHeader">
+                        <Setter Property="HorizontalContentAlignment" Value="Center" />
+                        <Setter Property="VerticalContentAlignment" Value="Center" />
+
+                        <Setter Property="FontFamily" Value="Roboto" />
+                        <Setter Property="FontSize" Value="16" />
+
+
+                        <Setter Property="Background" Value="MediumPurple" />
+                        <Setter Property="Foreground" Value="White" />
+                    </Style>
+
+
+                    <!--  DataGridRow  -->
+                    <Style TargetType="DataGridRow">
+                        <Setter Property="Height" Value="40" />
+                        <Setter Property="FontSize" Value="16" />
+
+
+                        <Style.Resources>
+                            <SolidColorBrush x:Key="{x:Static SystemColors.HighlightBrushKey}" Color="Lavender" />
+                            <SolidColorBrush x:Key="{x:Static SystemColors.ControlBrushKey}" Color="MediumPurple" />
+                            <SolidColorBrush x:Key="{x:Static SystemColors.HighlightTextBrushKey}" Color="Black" />
+                            <SolidColorBrush x:Key="{x:Static SystemColors.ControlTextBrushKey}" Color="Black" />
+                        </Style.Resources>
+                    </Style>
+
+                    <!--  DataGridCell  -->
+                    <Style TargetType="DataGridCell">
+                        <Setter Property="BorderThickness" Value="0" />
+                        <Setter Property="FocusVisualStyle" Value="{x:Null}" />
+                        <Style.Resources>
+                            <Style TargetType="ContentPresenter">
+                                <Setter Property="HorizontalAlignment" Value="Center" />
+                                <Setter Property="VerticalAlignment" Value="Center" />
+                            </Style>
+                        </Style.Resources>
+                    </Style>
+                </Style.Resources>
+            </Style>
+
+
+            <!--  SIDE PANEL DATA GRID Row  -->
+            <Style
+                x:Key="SidePanelDataGridRow"
+                BasedOn="{StaticResource MaterialDesignDataGridRow}"
+                TargetType="DataGridRow">
+                <Setter Property="Height" Value="40" />
+                <Setter Property="FontSize" Value="16" />
+
+
+                <Style.Resources>
+                    <SolidColorBrush x:Key="{x:Static SystemColors.HighlightBrushKey}" Color="Lavender" />
+                    <SolidColorBrush x:Key="{x:Static SystemColors.ControlBrushKey}" Color="MediumPurple" />
+                    <SolidColorBrush x:Key="{x:Static SystemColors.HighlightTextBrushKey}" Color="Black" />
+                    <SolidColorBrush x:Key="{x:Static SystemColors.ControlTextBrushKey}" Color="Black" />
+                </Style.Resources>
+            </Style>
+
+
+            <!--  DATA GRID BUTTON THAT IS VISIBLE ONLY ON ROW HOVER  -->
+            <Style
+                x:Key="DataGridButtonVisibleOnRowHover"
+                BasedOn="{StaticResource MaterialDesignRaisedButton}"
+                TargetType="Button">
+                <Setter Property="Visibility" Value="Collapsed" />
+                <Style.Triggers>
+                    <DataTrigger Binding="{Binding RelativeSource={RelativeSource AncestorType={x:Type DataGridRow}}, Path=IsMouseOver}" Value="True">
+                        <Setter Property="Visibility" Value="Visible" />
+                    </DataTrigger>
+                </Style.Triggers>
             </Style>
         </ResourceDictionary>
     </Application.Resources>

--- a/HealthcareSystemFrontends/SecretaryFrontend/App.xaml
+++ b/HealthcareSystemFrontends/SecretaryFrontend/App.xaml
@@ -1,8 +1,9 @@
-﻿<Application x:Class="ProjekatZdravoKorporacija.App"
-             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
-             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:local="clr-namespace:ProjekatZdravoKorporacija"
-             StartupUri="View/LogIn.xaml">
+﻿<Application
+    x:Class="ProjekatZdravoKorporacija.App"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="clr-namespace:ProjekatZdravoKorporacija"
+    StartupUri="View/LogIn.xaml">
 
     <Application.Resources>
         <ResourceDictionary>
@@ -13,23 +14,127 @@
                 <ResourceDictionary Source="pack://application:,,,/MaterialDesignColors;component/Themes/Recommended/Accent/MaterialDesignColor.Lime.xaml" />
             </ResourceDictionary.MergedDictionaries>
             <Style TargetType="Button">
-                <Setter Property="Background" Value="#FF1D3548"></Setter>
-                <Setter Property="BorderBrush" Value="#FF4AA2BF"></Setter>
-                <Setter Property="BorderThickness" Value="1"></Setter>
-                <Setter Property="Foreground" Value="White"></Setter>
-                <Setter Property="FontFamily" Value="Roboto"></Setter>
-                <Setter Property="FontSize" Value="20"></Setter>
-                <Setter Property="Height" Value="40"></Setter>
-                <Setter Property="FontWeight" Value="Medium"></Setter>
-                <Setter Property="HorizontalAlignment" Value="Center"></Setter>
-                <Setter Property="VerticalAlignment" Value="Center"></Setter>
+                <Setter Property="Background" Value="#FF1D3548" />
+                <Setter Property="BorderBrush" Value="#FF4AA2BF" />
+                <Setter Property="BorderThickness" Value="1" />
+                <Setter Property="Foreground" Value="White" />
+                <Setter Property="FontFamily" Value="Roboto" />
+                <Setter Property="FontSize" Value="20" />
+                <Setter Property="Height" Value="40" />
+                <Setter Property="FontWeight" Value="Medium" />
+                <Setter Property="HorizontalAlignment" Value="Center" />
+                <Setter Property="VerticalAlignment" Value="Center" />
             </Style>
             <Style TargetType="TextBlock">
-                <Setter Property="FontFamily" Value="Roboto"></Setter>
+                <Setter Property="FontFamily" Value="Roboto" />
             </Style>
             <Style TargetType="Label">
-                <Setter Property="FontFamily" Value="Roboto"></Setter>
-                <Setter Property="Foreground" Value="#FF1D3548"></Setter>
+                <Setter Property="FontFamily" Value="Roboto" />
+                <Setter Property="Foreground" Value="#FF1D3548" />
+            </Style>
+
+
+
+            <!--  GRAPHICAL EDITOR STYLES  -->
+
+            <!--  SIDE PANEL DATA GRID STYLE  -->
+            <!--  DataGrid  -->
+            <Style
+                x:Key="SidePanelDataGrid"
+                BasedOn="{StaticResource MaterialDesignDataGrid}"
+                TargetType="DataGrid">
+                <Setter Property="AutoGenerateColumns" Value="False" />
+                <Setter Property="CanUserAddRows" Value="False" />
+                <Setter Property="CanUserDeleteRows" Value="False" />
+                <Setter Property="CanUserReorderColumns" Value="False" />
+                <Setter Property="CanUserResizeColumns" Value="False" />
+                <Setter Property="CanUserResizeRows" Value="False" />
+                <Setter Property="ColumnHeaderHeight" Value="30" />
+                <Setter Property="HeadersVisibility" Value="Column" />
+                <Setter Property="IsReadOnly" Value="True" />
+                <Setter Property="SelectionMode" Value="Single" />
+
+                <Setter Property="VerticalScrollBarVisibility" Value="Visible" />
+                <Setter Property="ScrollViewer.CanContentScroll" Value="True" />
+
+
+                <Setter Property="HorizontalGridLinesBrush" Value="LightPink" />
+                <Setter Property="VerticalGridLinesBrush" Value="Transparent" />
+
+
+                <Style.Resources>
+                    <!--  DataGridColumnHeader  -->
+                    <Style TargetType="DataGridColumnHeader">
+                        <Setter Property="HorizontalContentAlignment" Value="Center" />
+                        <Setter Property="VerticalContentAlignment" Value="Center" />
+
+                        <Setter Property="FontFamily" Value="Roboto" />
+                        <Setter Property="FontSize" Value="16" />
+
+
+                        <Setter Property="Background" Value="MediumPurple" />
+                        <Setter Property="Foreground" Value="White" />
+                    </Style>
+
+
+                    <!--  DataGridRow  -->
+                    <Style TargetType="DataGridRow">
+                        <Setter Property="Height" Value="40" />
+                        <Setter Property="FontSize" Value="16" />
+
+
+                        <Style.Resources>
+                            <SolidColorBrush x:Key="{x:Static SystemColors.HighlightBrushKey}" Color="Lavender" />
+                            <SolidColorBrush x:Key="{x:Static SystemColors.ControlBrushKey}" Color="MediumPurple" />
+                            <SolidColorBrush x:Key="{x:Static SystemColors.HighlightTextBrushKey}" Color="Black" />
+                            <SolidColorBrush x:Key="{x:Static SystemColors.ControlTextBrushKey}" Color="Black" />
+                        </Style.Resources>
+                    </Style>
+
+                    <!--  DataGridCell  -->
+                    <Style TargetType="DataGridCell">
+                        <Setter Property="BorderThickness" Value="0" />
+                        <Setter Property="FocusVisualStyle" Value="{x:Null}" />
+                        <Style.Resources>
+                            <Style TargetType="ContentPresenter">
+                                <Setter Property="HorizontalAlignment" Value="Center" />
+                                <Setter Property="VerticalAlignment" Value="Center" />
+                            </Style>
+                        </Style.Resources>
+                    </Style>
+                </Style.Resources>
+            </Style>
+
+
+            <!--  SIDE PANEL DATA GRID Row  -->
+            <Style
+                x:Key="SidePanelDataGridRow"
+                BasedOn="{StaticResource MaterialDesignDataGridRow}"
+                TargetType="DataGridRow">
+                <Setter Property="Height" Value="40" />
+                <Setter Property="FontSize" Value="16" />
+
+
+                <Style.Resources>
+                    <SolidColorBrush x:Key="{x:Static SystemColors.HighlightBrushKey}" Color="Lavender" />
+                    <SolidColorBrush x:Key="{x:Static SystemColors.ControlBrushKey}" Color="MediumPurple" />
+                    <SolidColorBrush x:Key="{x:Static SystemColors.HighlightTextBrushKey}" Color="Black" />
+                    <SolidColorBrush x:Key="{x:Static SystemColors.ControlTextBrushKey}" Color="Black" />
+                </Style.Resources>
+            </Style>
+
+
+            <!--  DATA GRID BUTTON THAT IS VISIBLE ONLY ON ROW HOVER  -->
+            <Style
+                x:Key="DataGridButtonVisibleOnRowHover"
+                BasedOn="{StaticResource MaterialDesignRaisedButton}"
+                TargetType="Button">
+                <Setter Property="Visibility" Value="Collapsed" />
+                <Style.Triggers>
+                    <DataTrigger Binding="{Binding RelativeSource={RelativeSource AncestorType={x:Type DataGridRow}}, Path=IsMouseOver}" Value="True">
+                        <Setter Property="Visibility" Value="Visible" />
+                    </DataTrigger>
+                </Style.Triggers>
             </Style>
         </ResourceDictionary>
     </Application.Resources>


### PR DESCRIPTION
This branch contains mostly XAML code for different application functionalities.
I left few unimplemented methods in MainWindow.cs, but that will be replaced with implemented methods in next commits. I did that just to avoid deleting event handler declarations from xaml code. 

- I have moved DataGrid Styles to App.xaml
- I needed to copy  to App.xaml files of other WPF applications so that Application doesn't break, but in future I plan to make other WPF Apps use GraphicalEditor App.xaml without repeating code for GraphicalEditor Styles
- Most of MainWindow.xaml is switched to using Grids because of previous problems with DataGrids that StackPanels caused
- Transitions Animations for Canvas load and menu options switching

Small redesign of: 
- Panels for selected object's equipment and medicine overview
- Panel for searching map objects
- Panel for searching equipment and medicine
- Panel for searching map objects
