### PR TITLE
hotfix: fix DrugService instantiation issue on PatientWebApp startup

### DIFF
--- a/HealthcareSystem/PatientWebApp/Startup.cs
+++ b/HealthcareSystem/PatientWebApp/Startup.cs
@@ -39,6 +39,8 @@ using Backend.Repository.TherapyRepository.MySqlTherapyRepository;
 using Backend.Repository.SpecialtyRepository;
 using Backend.Repository.SpecialtyRepository.MySqlSpecialtyRepository;
 using Backend.Service.UsersAndWorkingTime;
+using Backend.Repository.DrugInRoomRepository;
+using Backend.Repository.DrugInRoomRepository.MySqlDrugInRoomRepository;
 
 namespace PatientWebApp
 {
@@ -84,6 +86,7 @@ namespace PatientWebApp
 
             services.AddScoped<IConfirmedDrugRepository, MySqlConfirmedDrugRepository>();
             services.AddScoped<IUnconfirmedDrugRepository, MySqlUnconfirmedDrugRepository>();
+            services.AddScoped<IDrugInRoomRepository, MySqlDrugInRoomRepository>();
             services.AddScoped<IDrugService, DrugService>();
 
             services.AddScoped<IDrugTypeRepository, MySqlDrugTypeRepository>();


### PR DESCRIPTION
A dependency was added to the DrugService class in #108, but the Startup class in the PatientWebApp wasn't updated accordingly. This lead to a runtime exception because the DI container couldn't instantiate the DrugService.