### PR TITLE
chore[d70]: delivery pipeline maintenance

### DIFF
--- a/HealthcareSystem/Backend/Model/DataSeededDbContext.cs
+++ b/HealthcareSystem/Backend/Model/DataSeededDbContext.cs
@@ -14,14 +14,11 @@ using System.Text;
 
 namespace Backend.Model
 {
-    class TestDbContext : MyDbContext
+    class DataSeededDbContext : MyDbContext
     {
-        private static readonly DbContextOptions<MyDbContext> options =
-            new DbContextOptionsBuilder<MyDbContext>().UseNpgsql(
-                "server=dummy;userid=dummy;pwd=dummy;port=5432;database=dummy").Options;
         private Random RandomGenerator { get; set; }
 
-        public TestDbContext() : base(options)
+        public DataSeededDbContext(DbContextOptions<MyDbContext> options) : base(options)
         {
             RandomGenerator = new Random();
         }

--- a/HealthcareSystem/Backend/Model/MySqlSeededDbContext.cs
+++ b/HealthcareSystem/Backend/Model/MySqlSeededDbContext.cs
@@ -1,0 +1,19 @@
+﻿using Microsoft.EntityFrameworkCore;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Backend.Model
+{
+    class MySqlSeededDbContext : DataSeededDbContext
+    {
+        private static readonly DbContextOptions<MyDbContext> options =
+            new DbContextOptionsBuilder<MyDbContext>().UseMySql(
+                "server=dummy;userid=dummy;pwd=dummy;port=3306;database=dummy").Options;
+
+        public MySqlSeededDbContext() : base(options)
+        {
+
+        }
+    }
+}

--- a/HealthcareSystem/Backend/Model/PostgreSeededDbContext.cs
+++ b/HealthcareSystem/Backend/Model/PostgreSeededDbContext.cs
@@ -1,0 +1,16 @@
+﻿using Microsoft.EntityFrameworkCore;
+
+namespace Backend.Model
+{
+    class PostgreSeededDbContext : DataSeededDbContext
+    {
+        private static readonly DbContextOptions<MyDbContext> options =
+            new DbContextOptionsBuilder<MyDbContext>().UseNpgsql(
+                "server=dummy;userid=dummy;pwd=dummy;port=5432;database=dummy").Options;
+
+        public PostgreSeededDbContext() : base(options)
+        {
+
+        }
+    }
+}

--- a/HealthcareSystem/Backend/Model/TestDbContext.cs
+++ b/HealthcareSystem/Backend/Model/TestDbContext.cs
@@ -1,0 +1,716 @@
+﻿using Backend.Model.Enums;
+using Backend.Model.Manager;
+using Backend.Model.Pharmacies;
+using Backend.Model.Users;
+using Microsoft.EntityFrameworkCore;
+using Model.Enums;
+using Model.Manager;
+using Model.NotificationSurveyAndFeedback;
+using Model.PerformingExamination;
+using Model.Users;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Backend.Model
+{
+    class TestDbContext : MyDbContext
+    {
+        private static readonly DbContextOptions<MyDbContext> options =
+            new DbContextOptionsBuilder<MyDbContext>().UseNpgsql(
+                "server=dummy;userid=dummy;pwd=dummy;port=5432;database=dummy").Options;
+        private Random RandomGenerator { get; set; }
+
+        public TestDbContext() : base(options)
+        {
+            RandomGenerator = new Random();
+        }
+
+        protected override void OnModelCreating(ModelBuilder builder)
+        {
+            base.OnModelCreating(builder);
+
+            #region CitiesAndCountries
+            builder.Entity<Country>().HasData(
+                new Country() { Name = "Srbija", Id = 1 },
+                new Country() { Name = "Crna Gora", Id = 2 },
+                new Country() { Name = "BiH", Id = 3 },
+                new Country() { Name = "Hrvatska", Id = 4 }
+                );
+
+            builder.Entity<City>().HasData(
+                new City() { Name = "Beograd", CountryId = 1, ZipCode = 1 },
+                new City() { Name = "Novi Sad", CountryId = 1, ZipCode = 2 },
+                new City() { Name = "Subotica", CountryId = 1, ZipCode = 3 },
+                new City() { Name = "Podgorica", CountryId = 2, ZipCode = 4 },
+                new City() { Name = "Budva", CountryId = 2, ZipCode = 5 },
+                new City() { Name = "Banja Luka", CountryId = 3, ZipCode = 6 },
+                new City() { Name = "Sarajevo", CountryId = 3, ZipCode = 7 },
+                new City() { Name = "Zagreb", CountryId = 4, ZipCode = 8 }
+                );
+            #endregion
+
+            #region Patients
+            builder.Entity<Patient>().HasData(
+                new Patient()
+                {
+                    Jmbg = "1309998775018",
+                    Name = "Ana",
+                    Surname = "Anić",
+                    DateOfBirth = new DateTime(1998, 9, 13),
+                    Gender = GenderType.F,
+                    CityZipCode = 1,
+                    Email = "ana_anic98@gmail.com",
+                    HomeAddress = "Tolstojeva 12",
+                    Password = "11111111",
+                    DateOfRegistration = DateTime.Now,
+                    IsActive = true,
+                    IsBlocked = false,
+                    Phone = "065897520",
+                    Username = "ana_anic98@gmail.com",
+                    ImageName = "picture1.jpg"
+                },
+                new Patient()
+                {
+                    Jmbg = "2711998896320",
+                    Name = "Žana",
+                    Surname = "Žanić",
+                    DateOfBirth = new DateTime(1998, 11, 27),
+                    Gender = GenderType.M,
+                    CityZipCode = 1,
+                    Email = "zana998@gmail.com",
+                    HomeAddress = "Bulevar Oslobođenja 100",
+                    Password = "12345678",
+                    DateOfRegistration = DateTime.Now,
+                    IsActive = true,
+                    IsBlocked = false,
+                    Phone = "065897520",
+                    Username = "zana998@gmail.com",
+                    ImageName = "profile_pic.jpg"
+                }
+                );
+            builder.Entity<PatientCard>().HasData(
+                new PatientCard()
+                {
+                    PatientJmbg = "1309998775018",
+                    BloodType = BloodType.A,
+                    RhFactor = RhFactorType.POSITIVE,
+                    HasInsurance = false,
+                    Id = -1
+                },
+                new PatientCard()
+                {
+                    PatientJmbg = "2711998896320",
+                    BloodType = BloodType.B,
+                    RhFactor = RhFactorType.POSITIVE,
+                    HasInsurance = false,
+                    Id = -2
+                }
+                );
+            #endregion
+
+            #region Specialties
+            builder.Entity<Specialty>().HasData(
+                new Specialty() { Name = "Epidemiolog", Id = 1 },
+                new Specialty() { Name = "Stomatolog", Id = 2 },
+                new Specialty() { Name = "Neurolog", Id = 3 },
+                new Specialty() { Name = "Kardiolog", Id = 4 },
+                new Specialty() { Name = "Opšti", Id = 5 }
+                );
+            #endregion
+
+            #region Doctors
+            builder.Entity<Doctor>().HasData(
+                new Doctor()
+                {
+                    Jmbg = "1234567891234",
+                    Name = "Mira",
+                    Surname = "Mirić",
+                    DateOfBirth = new DateTime(1950, 11, 27),
+                    Phone = "021457852",
+                    Email = "mira.miric@gmail.com",
+                    HomeAddress = "Maršala Tita 102",
+                    Username = "mira.miric@gmail.com",
+                    DateOfEmployment = new DateTime(2018, 05, 06),
+                    CityZipCode = 1,
+                    Gender = GenderType.F,
+                    NumberOfLicence = "11111111",
+                    Password = "MiraMira",
+                    DoctorsOfficeId = 9
+                },
+                new Doctor()
+                {
+                    Jmbg = "8520147896320",
+                    Name = "Dara",
+                    Surname = "Darić",
+                    DateOfBirth = new DateTime(1950, 11, 27),
+                    Phone = "021457852",
+                    Email = "dara@gmail.com",
+                    HomeAddress = "Maršala Tita 102",
+                    Username = "dara@gmail.com",
+                    DateOfEmployment = new DateTime(2010, 11, 15),
+                    CityZipCode = 1,
+                    Gender = GenderType.F,
+                    NumberOfLicence = "22222222",
+                    Password = "DaraDara",
+                    DoctorsOfficeId = 12
+                },
+                new Doctor()
+                {
+                    Jmbg = "0110983520145",
+                    Name = "Miloš",
+                    Surname = "Milošević",
+                    DateOfBirth = new DateTime(1983, 01, 10),
+                    Phone = "021852145",
+                    Email = "mmilosevic@gmail.com",
+                    HomeAddress = "Balzakova 18",
+                    Username = "mmilosevic@gmail.com",
+                    DateOfEmployment = new DateTime(2019, 04, 30),
+                    CityZipCode = 2,
+                    Gender = GenderType.M,
+                    NumberOfLicence = "11111111",
+                    Password = "milosevicm",
+                    DoctorsOfficeId = 20
+                },
+                new Doctor()
+                {
+                    Jmbg = "0323970501235",
+                    Name = "Žika",
+                    Surname = "Žikić",
+                    DateOfBirth = new DateTime(1970, 03, 23),
+                    Phone = "021752032",
+                    Email = "zikazikic@gmail.com",
+                    HomeAddress = "Narodnog Fronta 7",
+                    Username = "zikiczile@gmail.com",
+                    DateOfEmployment = new DateTime(2008, 10, 01),
+                    CityZipCode = 2,
+                    Gender = GenderType.M,
+                    NumberOfLicence = "11111111",
+                    Password = "zikiczile",
+                    DoctorsOfficeId = 25
+                },
+                new Doctor()
+                {
+                    Jmbg = "0606988520123",
+                    Name = "Marija",
+                    Surname = "Marić",
+                    DateOfBirth = new DateTime(1988, 06, 06),
+                    Phone = "021954201",
+                    Email = "marija988@gmail.com",
+                    HomeAddress = "Narodnog Fronta 45",
+                    Username = "marija988@gmail.com",
+                    DateOfEmployment = new DateTime(2020, 02, 05),
+                    CityZipCode = 1,
+                    Gender = GenderType.F,
+                    NumberOfLicence = "11111111",
+                    Password = "marija988",
+                    DoctorsOfficeId = 49
+                },
+                new Doctor()
+                {
+                    Jmbg = "2007975521021",
+                    Name = "Sara",
+                    Surname = "Sarić",
+                    DateOfBirth = new DateTime(1975, 07, 20),
+                    Phone = "021954201",
+                    Email = "sarasaric@gmail.com",
+                    HomeAddress = "Futoška 5",
+                    Username = "sarasaric@gmail.com",
+                    DateOfEmployment = new DateTime(2018, 05, 11),
+                    CityZipCode = 2,
+                    Gender = GenderType.F,
+                    NumberOfLicence = "11111111",
+                    Password = "sarasaric",
+                    DoctorsOfficeId = 51
+                });
+
+            builder.Entity<DoctorSpecialty>().HasData(
+                new DoctorSpecialty() { DoctorJmbg = "8520147896320", SpecialtyId = 1 },
+                new DoctorSpecialty() { DoctorJmbg = "0110983520145", SpecialtyId = 1 },
+                new DoctorSpecialty() { DoctorJmbg = "1234567891234", SpecialtyId = 2 },
+                new DoctorSpecialty() { DoctorJmbg = "0323970501235", SpecialtyId = 2 },
+                new DoctorSpecialty() { DoctorJmbg = "0606988520123", SpecialtyId = 3 },
+                new DoctorSpecialty() { DoctorJmbg = "2007975521021", SpecialtyId = 4 }
+                );
+            #endregion
+
+            #region Rooms
+            List<int> consulting = new List<int> { 9, 12, 13, 20, 21, 25, 49, 50, 51, 52, 53, 54 };
+            List<int> operation = new List<int> { 14, 15, 16, 18, 19, 41, 42, 55, 56, 57, 58, 59, 60 };
+            List<int> sick = new List<int> { 32, 33, 34, 35, 36, 37, 38, 39, 40 };
+
+            foreach (int id in consulting)
+                builder.Entity<Room>().HasData(new Room { Id = id, Usage = TypeOfUsage.CONSULTING_ROOM });
+            foreach (int id in operation)
+                builder.Entity<Room>().HasData(new Room { Id = id, Usage = TypeOfUsage.OPERATION_ROOM });
+            foreach (int id in sick)
+                builder.Entity<Room>().HasData(new Room { Id = id, Usage = TypeOfUsage.SICKROOM });
+            #endregion
+
+            #region DrugTypes
+            builder.Entity<DrugType>().HasData(
+                new DrugType() { Type = "tableta", Purpose = "lek za glavu", Id = 1 },
+                new DrugType() { Type = "tableta", Purpose = "lek za temperaturu", Id = 2 },
+                new DrugType() { Type = "kapsula", Purpose = "probiotik", Id = 3 }
+                );
+            #endregion
+
+            #region EquipmentTypes
+            builder.Entity<EquipmentType>().HasData(
+                new EquipmentType() { Name = "needle", IsConsumable = true, Id = 1 },
+                new EquipmentType() { Name = "bend", IsConsumable = true, Id = 2 },
+                new EquipmentType() { Name = "mask", IsConsumable = true, Id = 3 },
+                new EquipmentType() { Name = "bed", IsConsumable = false, Id = 4 },
+                new EquipmentType() { Name = "table", IsConsumable = false, Id = 5 },
+                new EquipmentType() { Name = "computer", IsConsumable = false, Id = 6 },
+                new EquipmentType() { Name = "chair", IsConsumable = false, Id = 7 },
+                new EquipmentType() { Name = "instrument", IsConsumable = false, Id = 8 }
+                );
+            #endregion
+
+            #region DrugTypes
+            builder.Entity<Drug>().HasData(
+                new Drug()
+                {
+                    DrugType_Id = 1,
+                    Name = "Brufen",
+                    Quantity = RandomGenerator.Next(5, 30),
+                    ExpirationDate = new DateTime(2021, 12, 13, 1, 8, 57),
+                    Producer = "Hemofarm",
+                    Id = 1
+                },
+                new Drug()
+                {
+                    DrugType_Id = 2,
+                    Name = "Metafeks",
+                    Quantity = RandomGenerator.Next(5, 30),
+                    ExpirationDate = new DateTime(2021, 12, 13, 1, 8, 57),
+                    Producer = "Hemofarm",
+                    Id = 2
+                },
+                new Drug()
+                {
+                    DrugType_Id = 1,
+                    Name = "Aspirin",
+                    Quantity = RandomGenerator.Next(5, 30),
+                    ExpirationDate = new DateTime(2021, 12, 13, 1, 8, 57),
+                    Producer = "Galenika",
+                    Id = 3
+                },
+                new Drug()
+                {
+                    DrugType_Id = 3,
+                    Name = "Bulardi",
+                    Quantity = RandomGenerator.Next(5, 30),
+                    ExpirationDate = new DateTime(2021, 12, 13, 1, 8, 57),
+                    Producer = "Hemofarm",
+                    Id = 4
+                });
+            #endregion
+
+            #region DrugsInRooms
+            for (int i = 1; i <= 4; i++)
+                foreach (int roomId in consulting)
+                    if (RandomGenerator.Next(2) == 1)
+                        builder.Entity<DrugInRoom>().HasData(new DrugInRoom()
+                        {
+                            DrugId = i,
+                            RoomNumber = roomId,
+                            Quantity = RandomGenerator.Next(10, 20)
+                        });
+            for (int i = 1; i <= 4; i++)
+                foreach (int roomId in operation)
+                    if (RandomGenerator.Next(2) == 1)
+                        builder.Entity<DrugInRoom>().HasData(new DrugInRoom()
+                        {
+                            DrugId = i,
+                            RoomNumber = roomId,
+                            Quantity = RandomGenerator.Next(10, 20)
+                        });
+            for (int i = 1; i <= 4; i++)
+                foreach (int roomId in sick)
+                    if (RandomGenerator.Next(2) == 1)
+                        builder.Entity<DrugInRoom>().HasData(new DrugInRoom()
+                        {
+                            DrugId = i,
+                            RoomNumber = roomId,
+                            Quantity = RandomGenerator.Next(10, 20)
+                        });
+            #endregion
+
+            #region EquipmentInRooms
+            int eid = -1;
+            for (int typeId = 1; typeId <= 8; typeId++)
+                foreach (int roomId in operation)
+                    if (RandomGenerator.Next(10) > 7)
+                    {
+                        int quantity = RandomGenerator.Next(10, 20);
+
+                        builder.Entity<Equipment>().HasData(new Equipment()
+                        {
+                            TypeId = typeId,
+                            Quantity = quantity,
+                            Id = eid
+                        });
+
+                        builder.Entity<EquipmentInRooms>().HasData(new EquipmentInRooms()
+                        {
+                            IdEquipment = eid,
+                            RoomNumber = roomId,
+                            Quantity = quantity
+                        });
+
+                        eid--;
+                    }
+            for (int typeId = 1; typeId <= 8; typeId++)
+                foreach (int roomId in consulting)
+                    if (RandomGenerator.Next(10) > 7)
+                    {
+                        int quantity = RandomGenerator.Next(10, 20);
+
+                        builder.Entity<Equipment>().HasData(new Equipment()
+                        {
+                            TypeId = typeId,
+                            Quantity = quantity,
+                            Id = eid
+                        });
+
+                        builder.Entity<EquipmentInRooms>().HasData(new EquipmentInRooms()
+                        {
+                            IdEquipment = eid,
+                            RoomNumber = roomId,
+                            Quantity = quantity
+                        });
+
+                        eid--;
+                    }
+            for (int typeId = 1; typeId <= 8; typeId++)
+                foreach (int roomId in sick)
+                    if (RandomGenerator.Next(10) > 7)
+                    {
+                        int quantity = RandomGenerator.Next(10, 20);
+
+                        builder.Entity<Equipment>().HasData(new Equipment()
+                        {
+                            TypeId = typeId,
+                            Quantity = quantity,
+                            Id = eid
+                        });
+
+                        builder.Entity<EquipmentInRooms>().HasData(new EquipmentInRooms()
+                        {
+                            IdEquipment = eid,
+                            RoomNumber = roomId,
+                            Quantity = quantity
+                        });
+
+                        eid--;
+                    }
+            #endregion
+
+            #region Feedback
+            builder.Entity<Feedback>().HasData(
+                new Feedback()
+                {
+                    Id = -1,
+                    CommentatorJmbg = "1309998775018",
+                    Comment = "Sve je super.",
+                    IsAllowedToPublish = true,
+                    IsPublished = true,
+                    SendingDate = new DateTime(2020, 10, 01)
+                },
+                new Feedback()
+                {
+                    Id = -2,
+                    CommentatorJmbg = "1309998775018",
+                    Comment = "Sviđa mi se Vaša bolnica.",
+                    IsAllowedToPublish = true,
+                    IsPublished = false,
+                    SendingDate = new DateTime(2020, 10, 13)
+                },
+                new Feedback()
+                {
+                    Id = -3,
+                    CommentatorJmbg = "2711998896320",
+                    Comment = "Odlična usluga.",
+                    IsAllowedToPublish = true,
+                    IsPublished = true,
+                    SendingDate = new DateTime(2020, 11, 05)
+                },
+                new Feedback()
+                {
+                    Id = -4,
+                    CommentatorJmbg = "2711998896320",
+                    Comment = "Zadovoljan sam uslugama.",
+                    IsAllowedToPublish = true,
+                    IsPublished = false,
+                    SendingDate = new DateTime(2020, 11, 13)
+                },
+                new Feedback()
+                {
+                    Id = -5,
+                    CommentatorJmbg = null,
+                    Comment = "Najbolji ste, sve pohvale!",
+                    IsAllowedToPublish = true,
+                    IsPublished = true,
+                    SendingDate = new DateTime(2020, 12, 06)
+                },
+                new Feedback()
+                {
+                    Id = -6,
+                    CommentatorJmbg = null,
+                    Comment = "Nisam zadovoljan.",
+                    IsAllowedToPublish = false,
+                    IsPublished = false,
+                    SendingDate = new DateTime(2020, 12, 18)
+                }
+                );
+            #endregion
+
+            #region Admin
+            builder.Entity<Admin>().HasData(
+                new Admin
+                {
+                    Jmbg = "0811965521021",
+                    Name = "Milan",
+                    Surname = "Milić",
+                    DateOfBirth = new DateTime(1965, 11, 08),
+                    Phone = "021954201",
+                    Email = "milic_milan@gmail.com",
+                    HomeAddress = "Aleja Svetog Save 100",
+                    Username = "milic_milan@gmail.com",
+                    CityZipCode = 3,
+                    Gender = GenderType.M,
+                    Password = "milanmilic965"
+                }
+                );
+            #endregion
+
+            #region Pharmacies
+            builder.Entity<PharmacySystem>().HasData(
+                new PharmacySystem()
+                {
+                    Id = -1,
+                    Name = "Janković",
+                    ApiKey = "ApiKey1",
+                    Url = "http://localhost:8080",
+                    ActionsBenefitsExchangeName = "exchange",
+                    ActionsBenefitsSubscribed = true,
+                    GrpcHost = "localhost",
+                    GrpcPort = 30051
+                }
+                );
+            #endregion
+
+            #region ActionBenefits
+            builder.Entity<ActionBenefit>().HasData(
+                new ActionBenefit()
+                {
+                    Id = -1,
+                    PharmacyId = -1,
+                    Subject = "Novogodišnji popust",
+                    Message = "Kapi za oči Proculin Tears na popustu 30%",
+                    IsPublic = true
+                },
+                new ActionBenefit()
+                {
+                    Id = -2,
+                    PharmacyId = -1,
+                    Subject = "Popust na penzionere",
+                    Message = "Renomal gel za zglobove na popustu 40%",
+                    IsPublic = true
+                },
+                new ActionBenefit()
+                {
+                    Id = -3,
+                    PharmacyId = -1,
+                    Subject = "Novogodišnji popust",
+                    Message = "Corega pasta za protezu na popustu 50%",
+                    IsPublic = true
+                }
+                );
+            #endregion
+
+            #region DrugConsumptions
+            int consumptionId = -1;
+            DateTime startDate = DateTime.Now;
+            DateTime endDate = DateTime.Now.AddDays(10);
+            for (DateTime current = startDate; current < endDate; current = current.AddDays(1))
+                for (int drugId = 1; drugId <= 4; drugId++)
+                    if (RandomGenerator.Next(2) == 1)
+                        builder.Entity<DrugConsumption>().HasData(new DrugConsumption()
+                        {
+                            Id = consumptionId--,
+                            DrugId = drugId,
+                            Date = current,
+                            Quantity = RandomGenerator.Next(5, 20)
+                        });
+            #endregion
+
+            #region Examinations
+            DateTime start = DateTime.Now.Date.AddDays(10).AddHours(7);
+            DateTime end = DateTime.Now.Date.AddDays(13).AddHours(17);
+
+            int examid = -1;
+
+            for (DateTime current = start; current < end; current = current.AddMinutes(30))
+            {
+                if (CheckIfTimeValid(current))
+                {
+                    builder.Entity<Examination>().HasData(new Examination
+                    {
+                        Id = examid--,
+                        Type = TypeOfExamination.GENERAL,
+                        DoctorJmbg = "8520147896320",
+                        IdPatientCard = -2,
+                        IdRoom = consulting[0],
+                        DateAndTime = current,
+                        IsSurveyCompleted = false,
+                        ExaminationStatus = ExaminationStatus.CREATED
+                    });
+                    continue;
+                }
+                current = new DateTime(current.Year, current.Month, current.Day, 6, 30, 0);
+                current = current.AddDays(1);
+            }
+            builder.Entity<Examination>().HasData(
+                new Examination
+                {
+                    Id = examid--,
+                    Type = TypeOfExamination.GENERAL,
+                    DoctorJmbg = "8520147896320",
+                    IdPatientCard = -2,
+                    IdRoom = 9,
+                    DateAndTime = DateTime.Now.Date.AddDays(-10).AddHours(8).AddMinutes(30),
+                    IsSurveyCompleted = false,
+                    ExaminationStatus = ExaminationStatus.CANCELED
+                },
+                new Examination
+                {
+                    Id = examid--,
+                    Type = TypeOfExamination.GENERAL,
+                    DoctorJmbg = "8520147896320",
+                    IdPatientCard = -2,
+                    IdRoom = 9,
+                    DateAndTime = DateTime.Now.Date.AddDays(-12).AddHours(10),
+                    IsSurveyCompleted = false,
+                    ExaminationStatus = ExaminationStatus.CANCELED
+                },
+                new Examination
+                {
+                    Id = examid--,
+                    Type = TypeOfExamination.GENERAL,
+                    DoctorJmbg = "8520147896320",
+                    IdPatientCard = -2,
+                    IdRoom = 9,
+                    DateAndTime = DateTime.Now.Date.AddDays(-15).AddHours(12).AddMinutes(30),
+                    IsSurveyCompleted = false,
+                    ExaminationStatus = ExaminationStatus.CANCELED
+                }
+                );
+
+            List<Examination> finished = new List<Examination>() { new Examination
+                {
+                    Id = examid--,
+                    Type = TypeOfExamination.GENERAL,
+                    DoctorJmbg = "8520147896320",
+                    IdPatientCard = -1,
+                    IdRoom = 9,
+                    DateAndTime = DateTime.Now.Date.AddDays(-15).AddHours(14),
+                    IsSurveyCompleted = true,
+                    ExaminationStatus = ExaminationStatus.FINISHED,
+                    Anamnesis = "Sinuzitis"
+                },
+                new Examination
+                {
+                    Id = examid--,
+                    Type = TypeOfExamination.GENERAL,
+                    DoctorJmbg = "0606988520123",
+                    IdPatientCard = -1,
+                    IdRoom = 9,
+                    DateAndTime = DateTime.Now.Date.AddDays(-10).AddHours(9).AddMinutes(30),
+                    IsSurveyCompleted = false,
+                    ExaminationStatus = ExaminationStatus.FINISHED,
+                    Anamnesis = "Upala uha"
+                }
+            };
+            builder.Entity<Examination>().HasData(finished);
+            builder.Entity<Examination>().HasData(
+                new Examination
+                {
+                    Id = examid--,
+                    Type = TypeOfExamination.GENERAL,
+                    DoctorJmbg = "0323970501235",
+                    IdPatientCard = -1,
+                    IdRoom = 9,
+                    DateAndTime = DateTime.Now.Date.AddDays(-5).AddHours(11).AddMinutes(30),
+                    IsSurveyCompleted = false,
+                    ExaminationStatus = ExaminationStatus.FINISHED,
+                    Anamnesis = "Upala pluća"
+                },
+                new Examination
+                {
+                    Id = examid--,
+                    Type = TypeOfExamination.GENERAL,
+                    DoctorJmbg = "0606988520123",
+                    IdPatientCard = -1,
+                    IdRoom = 9,
+                    DateAndTime = DateTime.Now.Date.AddDays(1).AddHours(10).AddMinutes(30),
+                    IsSurveyCompleted = false,
+                    ExaminationStatus = ExaminationStatus.CREATED
+                },
+                new Examination
+                {
+                    Id = examid--,
+                    Type = TypeOfExamination.GENERAL,
+                    DoctorJmbg = "8520147896320",
+                    IdPatientCard = -1,
+                    IdRoom = 9,
+                    DateAndTime = DateTime.Now.Date.AddDays(13).AddHours(7),
+                    IsSurveyCompleted = false,
+                    ExaminationStatus = ExaminationStatus.CREATED
+                },
+                new Examination
+                {
+                    Id = examid--,
+                    Type = TypeOfExamination.GENERAL,
+                    DoctorJmbg = "0606988520123",
+                    IdPatientCard = -1,
+                    IdRoom = 9,
+                    DateAndTime = DateTime.Now.Date.AddDays(-2).AddHours(10),
+                    IsSurveyCompleted = false,
+                    ExaminationStatus = ExaminationStatus.CANCELED
+                }
+                );
+            #endregion
+
+            #region Therapies
+            int therapyId = -1;
+            foreach (Examination e in finished)
+            {
+                builder.Entity<Therapy>().HasData(
+                    new Therapy()
+                    {
+                        Id = therapyId--,
+                        IdExamination = e.Id,
+                        Diagnosis = e.Anamnesis,
+                        StartDate = e.DateAndTime,
+                        EndDate = e.DateAndTime.AddDays(RandomGenerator.Next(1, 10)),
+                        DailyDose = RandomGenerator.Next(1, 5),
+                        IdDrug = RandomGenerator.Next(1, 4)
+                    }
+                    );
+            }
+            #endregion
+        }
+
+        private bool CheckIfTimeValid(DateTime dateTime)
+        {
+            if (TimeSpan.Compare(dateTime.TimeOfDay, new TimeSpan(7, 0, 0)) < 0)
+                return false;
+            if (TimeSpan.Compare(dateTime.TimeOfDay, new TimeSpan(17, 0, 0)) >= 0)
+                return false;
+            return true;
+        }
+    }
+}

--- a/HealthcareSystem/Dockerfile.postgre
+++ b/HealthcareSystem/Dockerfile.postgre
@@ -4,7 +4,7 @@ ENV ASPNETCORE_ENVIRONMENT Test
 RUN dotnet tool install -g dotnet-ef --version 3.1.9
 WORKDIR /src/Backend
 COPY Backend/ .
-RUN dotnet-ef dbcontext script -c "TestDbContext" -p "/src/Backend/Backend.csproj" -o /init.sql
+RUN dotnet-ef dbcontext script -c "PostgreSeededDbContext" -p "/src/Backend/Backend.csproj" -o /init.sql
 
 FROM postgres:13-alpine
 COPY --from=sql-script /init.sql /docker-entrypoint-initdb.d/init.sql

--- a/HealthcareSystem/Dockerfile.postgre
+++ b/HealthcareSystem/Dockerfile.postgre
@@ -4,9 +4,7 @@ ENV ASPNETCORE_ENVIRONMENT Test
 RUN dotnet tool install -g dotnet-ef --version 3.1.9
 WORKDIR /src/Backend
 COPY Backend/ .
-WORKDIR /src/PatientWebApp
-COPY PatientWebApp/ .
-RUN dotnet-ef dbcontext script -c "MyDbContext" -p "/src/PatientWebApp/PatientWebApp.csproj" -o /init.sql
+RUN dotnet-ef dbcontext script -c "TestDbContext" -p "/src/Backend/Backend.csproj" -o /init.sql
 
 FROM postgres:13-alpine
 COPY --from=sql-script /init.sql /docker-entrypoint-initdb.d/init.sql

--- a/HealthcareSystem/E2ETests/E2EPatientWebAppRegistration.cs
+++ b/HealthcareSystem/E2ETests/E2EPatientWebAppRegistration.cs
@@ -14,9 +14,6 @@ namespace E2ETests
             IWebDriver driver = new FirefoxDriver();
             WebDriverWait wait = new WebDriverWait(driver, TimeSpan.FromSeconds(10));
             driver.Navigate().GoToUrl("https://vlaksi-patientwebapp.herokuapp.com/html/index.html");
-
-            driver.FindElement(By.ClassName("nav-link")).Click();
-            driver.FindElement(By.Id("register")).Click();
         }
     }
 }

--- a/HealthcareSystem/FeedbackAndSurveyService/Controller/PingController.cs
+++ b/HealthcareSystem/FeedbackAndSurveyService/Controller/PingController.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace FeedbackAndSurveyService.Controller
+{
+    [Route("api/[controller]")]
+    [ApiController]
+    public class PingController : ControllerBase
+    {
+        [HttpGet]
+        public IActionResult Ping()
+        {
+            return Ok("Successfully pinged.");
+        }
+    }
+}

--- a/HealthcareSystem/FeedbackAndSurveyService/Properties/launchSettings.json
+++ b/HealthcareSystem/FeedbackAndSurveyService/Properties/launchSettings.json
@@ -12,6 +12,7 @@
     "IIS Express": {
       "commandName": "IISExpress",
       "launchBrowser": true,
+      "launchUrl": "api/ping",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
@@ -19,6 +20,7 @@
     "FeedbackAndSurveyService": {
       "commandName": "Project",
       "launchBrowser": true,
+      "launchUrl": "api/ping",
       "applicationUrl": "http://localhost:5000",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"

--- a/HealthcareSystem/GraphicalEditorServer/Controllers/PingController.cs
+++ b/HealthcareSystem/GraphicalEditorServer/Controllers/PingController.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace GraphicalEditorServer.Controllers
+{
+    [Route("api/[controller]")]
+    [ApiController]
+    public class PingController : ControllerBase
+    {
+        [HttpGet]
+        public IActionResult Ping()
+        {
+            return Ok("Successfully pinged.");
+        }
+    }
+}

--- a/HealthcareSystem/GraphicalEditorServer/Properties/launchSettings.json
+++ b/HealthcareSystem/GraphicalEditorServer/Properties/launchSettings.json
@@ -12,7 +12,7 @@
     "IIS Express": {
       "commandName": "IISExpress",
       "launchBrowser": true,
-      "launchUrl": "weatherforecast",
+      "launchUrl": "api/ping",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
@@ -20,7 +20,7 @@
     "GraphicalEditorServer": {
       "commandName": "Project",
       "launchBrowser": true,
-      "launchUrl": "weatherforecast",
+      "launchUrl": "api/ping",
       "applicationUrl": "http://localhost:5000",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"

--- a/HealthcareSystem/NotificationService/Controller/PingController.cs
+++ b/HealthcareSystem/NotificationService/Controller/PingController.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace NotificationService.Controller
+{
+    [Route("api/[controller]")]
+    [ApiController]
+    public class PingController : ControllerBase
+    {
+        [HttpGet]
+        public IActionResult Ping()
+        {
+            return Ok("Successfully pinged.");
+        }
+    }
+}

--- a/HealthcareSystem/NotificationService/Properties/launchSettings.json
+++ b/HealthcareSystem/NotificationService/Properties/launchSettings.json
@@ -12,6 +12,7 @@
     "IIS Express": {
       "commandName": "IISExpress",
       "launchBrowser": true,
+      "launchUrl": "api/ping",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
@@ -19,6 +20,7 @@
     "NotificationService": {
       "commandName": "Project",
       "launchBrowser": true,
+      "launchUrl": "api/ping",
       "applicationUrl": "http://localhost:5000",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"

--- a/HealthcareSystem/PatientService/Controller/PingController.cs
+++ b/HealthcareSystem/PatientService/Controller/PingController.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace PatientService.Controller
+{
+    [Route("api/[controller]")]
+    [ApiController]
+    public class PingController : ControllerBase
+    {
+        [HttpGet]
+        public IActionResult Ping()
+        {
+            return Ok("Successfully pinged.");
+        }
+    }
+}

--- a/HealthcareSystem/PatientService/Properties/launchSettings.json
+++ b/HealthcareSystem/PatientService/Properties/launchSettings.json
@@ -12,6 +12,7 @@
     "IIS Express": {
       "commandName": "IISExpress",
       "launchBrowser": true,
+      "launchUrl": "api/ping",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
@@ -19,6 +20,7 @@
     "PatientService": {
       "commandName": "Project",
       "launchBrowser": true,
+      "launchUrl": "api/ping",
       "applicationUrl": "http://localhost:5000",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"

--- a/HealthcareSystem/PatientWebApp/Controllers/PingController.cs
+++ b/HealthcareSystem/PatientWebApp/Controllers/PingController.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace PatientWebApp.Controllers
+{
+    [Authorize]
+    [Route("api/[controller]")]
+    [ApiController]
+    public class PingController : ControllerBase
+    {
+        [AllowAnonymous]
+        [HttpGet]
+        public IActionResult Ping()
+        {
+            return Ok("Successfully pinged.");
+        }
+    }
+}

--- a/HealthcareSystem/PatientWebApp/Startup.cs
+++ b/HealthcareSystem/PatientWebApp/Startup.cs
@@ -188,30 +188,7 @@ namespace PatientWebApp
             {
                 app.UseDeveloperExceptionPage();
             }
-
-            if (env.IsDevelopment() || env.EnvironmentName.ToLower().Equals("test"))
-            {
-                using (var scope = app.ApplicationServices.CreateScope())
-                using (var context = scope.ServiceProvider.GetService<MyDbContext>())
-                {
-                    try
-                    {
-                        Console.WriteLine("Data seeding started.");
-                        DataSeeder seeder = new DataSeeder(true);
-                        if (seeder.IsAlreadySeeded(context))
-                            Console.WriteLine("Data already seeded.");
-                        else
-                            seeder.SeedAll(context);
-                        Console.WriteLine("Data seeding finished.");
-                    }
-                    catch (Exception e)
-                    {
-                        Console.WriteLine("Data seeding failed.");
-                        Console.WriteLine(e.Message);
-                        Console.WriteLine(e.StackTrace);
-                    }
-                }
-            }
+            
             DefaultFilesOptions options = new DefaultFilesOptions();
             options.DefaultFileNames.Clear();
             options.DefaultFileNames.Add("/html/index.html");

--- a/HealthcareSystem/UserService/Controllers/PingController.cs
+++ b/HealthcareSystem/UserService/Controllers/PingController.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace UserService.Controllers
+{
+    [Route("api/[controller]")]
+    [ApiController]
+    public class PingController : ControllerBase
+    {
+        [HttpGet]
+        public IActionResult Ping()
+        {
+            return Ok("Successfully pinged.");
+        }
+    }
+}

--- a/HealthcareSystem/UserService/Properties/launchSettings.json
+++ b/HealthcareSystem/UserService/Properties/launchSettings.json
@@ -12,7 +12,7 @@
     "IIS Express": {
       "commandName": "IISExpress",
       "launchBrowser": true,
-      "launchUrl": "api/country",
+      "launchUrl": "api/ping",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }
@@ -20,7 +20,7 @@
     "UserService": {
       "commandName": "Project",
       "launchBrowser": true,
-      "launchUrl": "api/country",
+      "launchUrl": "api/ping",
       "applicationUrl": "http://localhost:5000",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"

--- a/pipelines/cd/e2e-on-heroku.yml
+++ b/pipelines/cd/e2e-on-heroku.yml
@@ -28,7 +28,7 @@ stages:
             echo "----- Installing EF Core. -----"
             dotnet tool install --global dotnet-ef --version 3.1.9
             echo "----- Generating script. -----"
-            dotnet-ef dbcontext script -c "TestDbContext" -p "./HealthcareSystem/Backend/Backend.csproj" -o init.sql
+            dotnet-ef dbcontext script -c "PostgreSeededDbContext" -p "./HealthcareSystem/Backend/Backend.csproj" -o init.sql
           pwsh: true
       - task: PowerShell@2
         displayName: "Initialize Heroku Postgres"

--- a/pipelines/cd/e2e-on-heroku.yml
+++ b/pipelines/cd/e2e-on-heroku.yml
@@ -19,7 +19,7 @@ stages:
           targetType: 'inline'
           script: |
             echo "----- Installing EF Core. -----"
-            dotnet tool install --global dotnet-ef --version 3.1.9
+            dotnet tool install dotnet-ef --version 3.1.9
             echo "----- Generating script. -----"
             dotnet-ef dbcontext script -c "TestDbContext" -p "./HealthcareSystem/Backend/Backend.csproj" -o init.sql
           pwsh: true
@@ -34,6 +34,7 @@ stages:
             Get-Content init.sql | heroku pg:psql DATABASE_URL --app vlaksi-patient-service
           pwsh: true     
   - job: Wait
+    dependsOn: ResetDb
     displayName: Wait for component redeployments
     pool: Server
     steps:

--- a/pipelines/cd/e2e-on-heroku.yml
+++ b/pipelines/cd/e2e-on-heroku.yml
@@ -4,22 +4,29 @@ trigger:
     - develop
 pr: none
 
+pool:
+  vmImage: 'ubuntu-18.04'
+
 stages:
 - stage: Prepare
   displayName: Prepare for tests
+  variables:
+    HEROKU_API_KEY: 8418d6b4-7423-404b-81cf-23abcd968591
   jobs:  
   - job: ResetDb
     displayName: Reset database
-    pool:
-      vmImage: 'ubuntu-18.04'
     steps:
+      - task: UseDotNet@2
+        inputs:
+          packageType: 'sdk'
+          version: '3.1.x'
       - task: PowerShell@2
         displayName: "Generate SQL script"
         inputs:
           targetType: 'inline'
           script: |
             echo "----- Installing EF Core. -----"
-            dotnet tool install dotnet-ef --version 3.1.9
+            dotnet tool install --global dotnet-ef --version 3.1.9
             echo "----- Generating script. -----"
             dotnet-ef dbcontext script -c "TestDbContext" -p "./HealthcareSystem/Backend/Backend.csproj" -o init.sql
           pwsh: true
@@ -33,6 +40,7 @@ stages:
             echo "----- Initializing database. -----"
             Get-Content init.sql | heroku pg:psql DATABASE_URL --app vlaksi-patient-service
           pwsh: true     
+
   - job: Wait
     dependsOn: ResetDb
     displayName: Wait for component redeployments
@@ -44,8 +52,6 @@ stages:
 
 - stage: Smoke
   displayName: Run smoke tests
-  pool:
-    vmImage: 'ubuntu-18.04'
   jobs:
   - job: UserService
     steps:
@@ -53,13 +59,13 @@ stages:
         displayName: "Ping test"
         inputs:
           filePath: 'pipelines/cd/smoke.ps1'
-          arguments: '-uri https://$vlaksi-user-service.herokuapp.com/api/ping -code 200'
+          arguments: '-uri https://vlaksi-user-service.herokuapp.com/api/ping -code 200'
           pwsh: true
       - task: PowerShell@2
         displayName: "Database connection test"
         inputs:
           filePath: 'pipelines/cd/smoke.ps1'
-          arguments: '-uri https://$vlaksi-user-service.herokuapp.com/api/countries -code 200'
+          arguments: '-uri https://vlaksi-user-service.herokuapp.com/api/country -code 200'
           pwsh: true
 
   - job: FeedbackAndSurveyService
@@ -68,13 +74,13 @@ stages:
         displayName: "Ping test"
         inputs:
           filePath: 'pipelines/cd/smoke.ps1'
-          arguments: '-uri https://$vlaksi-feedback-and-survey.herokuapp.com/api/ping -code 200'
+          arguments: '-uri https://vlaksi-feedback-and-survey.herokuapp.com/api/ping -code 200'
           pwsh: true
       - task: PowerShell@2
         displayName: "Database connection test"
         inputs:
           filePath: 'pipelines/cd/smoke.ps1'
-          arguments: '-uri https://$vlaksi-feedback-and-survey.herokuapp.com/api/feedback/published -code 200'
+          arguments: '-uri https://vlaksi-feedback-and-survey.herokuapp.com/api/feedback/published -code 200'
           pwsh: true
 
   - job: NotificationService
@@ -83,7 +89,7 @@ stages:
         displayName: "Ping test"
         inputs:
           filePath: 'pipelines/cd/smoke.ps1'
-          arguments: '-uri https://$vlaksi-notification-service.herokuapp.com/api/ping -code 200'
+          arguments: '-uri https://vlaksi-notification-service.herokuapp.com/api/ping -code 200'
           pwsh: true
 
   - job: PatientService
@@ -92,7 +98,7 @@ stages:
         displayName: "Ping test"
         inputs:
           filePath: 'pipelines/cd/smoke.ps1'
-          arguments: '-uri https://$vlaksi-patient-service.herokuapp.com/api/ping -code 200'
+          arguments: '-uri https://vlaksi-patient-service.herokuapp.com/api/ping -code 200'
           pwsh: true
 
   - job: ApiGateway
@@ -101,14 +107,12 @@ stages:
         displayName: "Ping test"
         inputs:
           filePath: 'pipelines/cd/smoke.ps1'
-          arguments: '-uri https://$vlaksi-patientwebapp.herokuapp.com/api/ping -code 200'
+          arguments: '-uri https://vlaksi-patientwebapp.herokuapp.com/api/ping -code 200'
           pwsh: true
 
 
 - stage: E2E
   displayName: Run E2E tests
-  pool:
-    vmImage: 'ubuntu-18.04'
   variables:
     e2etests: 'HealthcareSystem/E2ETests/E2ETests.csproj'
   jobs:

--- a/pipelines/cd/e2e-on-heroku.yml
+++ b/pipelines/cd/e2e-on-heroku.yml
@@ -1,0 +1,122 @@
+trigger:
+  branches:
+    include:
+    - develop
+pr: none
+
+stages:
+- stage: Prepare
+  displayName: Prepare for tests
+  jobs:  
+  - job: ResetDb
+    displayName: Reset database
+    pool:
+      vmImage: 'ubuntu-18.04'
+    steps:
+      - task: PowerShell@2
+        displayName: "Generate SQL script"
+        inputs:
+          targetType: 'inline'
+          script: |
+            echo "----- Installing EF Core. -----"
+            dotnet tool install --global dotnet-ef --version 3.1.9
+            echo "----- Generating script. -----"
+            dotnet-ef dbcontext script -c "TestDbContext" -p "./HealthcareSystem/Backend/Backend.csproj" -o init.sql
+          pwsh: true
+      - task: PowerShell@2
+        displayName: "Initialize Heroku Postgres"
+        inputs:
+          targetType: 'inline'
+          script: |
+            echo "----- Reseting database. -----"
+            heroku pg:reset DATABASE_URL --app vlaksi-patientwebapp --confirm vlaksi-patientwebapp
+            echo "----- Initializing database. -----"
+            Get-Content init.sql | heroku pg:psql DATABASE_URL --app vlaksi-patientwebapp
+          pwsh: true     
+  - job: Wait
+    displayName: Wait for component redeployments
+    pool: Server
+    steps:
+    - task: Delay@1
+      inputs:
+        delayForMinutes: '5' 
+
+- stage: Smoke
+  displayName: Run smoke tests
+  pool:
+    vmImage: 'ubuntu-18.04'
+  jobs:
+  - job: UserService
+    steps:
+      - task: PowerShell@2
+        displayName: "Ping test"
+        inputs:
+          filePath: 'pipelines/cd/smoke.ps1'
+          arguments: '-uri https://$vlaksi-user-service.herokuapp.com/api/ping -code 200'
+          pwsh: true
+      - task: PowerShell@2
+        displayName: "Database connection test"
+        inputs:
+          filePath: 'pipelines/cd/smoke.ps1'
+          arguments: '-uri https://$vlaksi-user-service.herokuapp.com/api/countries -code 200'
+          pwsh: true
+
+  - job: FeedbackAndSurveyService
+    steps:
+      - task: PowerShell@2
+        displayName: "Ping test"
+        inputs:
+          filePath: 'pipelines/cd/smoke.ps1'
+          arguments: '-uri https://$vlaksi-feedback-and-survey.herokuapp.com/api/ping -code 200'
+          pwsh: true
+      - task: PowerShell@2
+        displayName: "Database connection test"
+        inputs:
+          filePath: 'pipelines/cd/smoke.ps1'
+          arguments: '-uri https://$vlaksi-feedback-and-survey.herokuapp.com/api/feedback/published -code 200'
+          pwsh: true
+
+  - job: NotificationService
+    steps:
+      - task: PowerShell@2
+        displayName: "Ping test"
+        inputs:
+          filePath: 'pipelines/cd/smoke.ps1'
+          arguments: '-uri https://$vlaksi-notification-service.herokuapp.com/api/ping -code 200'
+          pwsh: true
+
+  - job: PatientService
+    steps:
+      - task: PowerShell@2
+        displayName: "Ping test"
+        inputs:
+          filePath: 'pipelines/cd/smoke.ps1'
+          arguments: '-uri https://$vlaksi-patient-service.herokuapp.com/api/ping -code 200'
+          pwsh: true
+
+  - job: ApiGateway
+    steps:
+      - task: PowerShell@2
+        displayName: "Ping test"
+        inputs:
+          filePath: 'pipelines/cd/smoke.ps1'
+          arguments: '-uri https://$vlaksi-patientwebapp.herokuapp.com/api/ping -code 200'
+          pwsh: true
+
+
+- stage: E2E
+  displayName: Run E2E tests
+  pool:
+    vmImage: 'ubuntu-18.04'
+  variables:
+    e2etests: 'HealthcareSystem/E2ETests/E2ETests.csproj'
+  jobs:
+  - job: Test
+    steps:
+    - task: PowerShell@2
+      displayName: 'Run tests'
+      inputs:
+        targetType: 'inline'
+        script: |
+          #
+          dotnet test $(e2etests)

--- a/pipelines/cd/e2e-on-heroku.yml
+++ b/pipelines/cd/e2e-on-heroku.yml
@@ -114,7 +114,7 @@ stages:
 - stage: E2E
   displayName: Run E2E tests
   variables:
-    e2etests: 'HealthcareSystem/E2ETests/E2ETests.csproj'
+    e2etests: 'HealthcareSystem/SeleniumTests/SeleniumTests.csproj'
   jobs:
   - job: Test
     steps:
@@ -124,4 +124,4 @@ stages:
         targetType: 'inline'
         script: |
           #
-          dotnet test $(e2etests)
+          #dotnet test $(e2etests)

--- a/pipelines/cd/e2e-on-heroku.yml
+++ b/pipelines/cd/e2e-on-heroku.yml
@@ -29,9 +29,9 @@ stages:
           targetType: 'inline'
           script: |
             echo "----- Reseting database. -----"
-            heroku pg:reset DATABASE_URL --app vlaksi-patientwebapp --confirm vlaksi-patientwebapp
+            heroku pg:reset DATABASE_URL --app vlaksi-patient-service --confirm vlaksi-patient-service
             echo "----- Initializing database. -----"
-            Get-Content init.sql | heroku pg:psql DATABASE_URL --app vlaksi-patientwebapp
+            Get-Content init.sql | heroku pg:psql DATABASE_URL --app vlaksi-patient-service
           pwsh: true     
   - job: Wait
     displayName: Wait for component redeployments

--- a/pipelines/cd/editor-server-delivery.yml
+++ b/pipelines/cd/editor-server-delivery.yml
@@ -77,6 +77,6 @@ stages:
       - task: PowerShell@2
         displayName: "Ping test"
         inputs:
-          filePath: 'smoke.ps1'
+          filePath: 'pipelines/cd/smoke.ps1'
           arguments: '-uri https://$(herokuProject).herokuapp.com/api/ping -code 200'
           pwsh: true

--- a/pipelines/cd/editor-server-delivery.yml
+++ b/pipelines/cd/editor-server-delivery.yml
@@ -1,0 +1,82 @@
+trigger:
+  branches:
+    include:
+    - develop
+  paths:
+    include:
+    - 'HealthcareSystem/GraphicalEditorServer/*'
+    - 'HealthcareSystem/Backend/*'
+pr: none
+
+pool:
+  vmImage: 'ubuntu-18.04'
+
+variables:
+  dockerRegistry: 'pufkedockerhub'
+  project: 'HealthcareSystem/GraphicalEditorServer/GraphicalEditorServer.csproj'
+  dockerfile: 'HealthcareSystem/GraphicalEditorServer/Dockerfile'
+  dockerImage: 'pufke/graphicaleditor'
+  herokuProject: 'vlaksi-graphicaleditor'
+
+stages:
+- stage: CI
+  jobs:
+  - job: Docker
+    steps:
+    - task: Bash@3
+      displayName: 'Prepare context for Docker'
+      inputs:
+        targetType: 'inline'
+        script: |
+          docker --version
+          dotnet publish $(project) -c Release -o publish
+          cp $(dockerfile) publish/Dockerfile  
+    - task: Docker@2
+      displayName: 'Build and push Docker image'
+      inputs:
+        containerRegistry: '$(dockerRegistry)'
+        repository: '$(dockerImage)'
+        command: 'buildAndPush'
+        Dockerfile: 'publish/Dockerfile'
+        buildContext: 'publish'
+        tags: |
+          $(Build.BuildId)
+          latest
+
+- stage: CD
+  variables:
+    HEROKU_API_KEY: 8418d6b4-7423-404b-81cf-23abcd968591
+  jobs:
+  - deployment: GraphicalEditor   
+    environment: 'Test'
+    strategy:
+      runOnce:
+        deploy:                 
+          steps:
+            - task: PowerShell@2
+              displayName: "Heroku Deployment"
+              inputs:
+                targetType: 'inline'
+                script: |
+                  echo "----- Logging in to Heroku registry. -----"
+                  heroku container:login
+                  echo '----- Pulling image from DockerHub. -----'
+                  docker pull $(dockerImage)
+                  echo '----- Pushing to Heroku registry. -----'
+                  docker tag $(dockerImage) registry.heroku.com/$(herokuProject)/web
+                  docker push registry.heroku.com/$(herokuProject)/web
+                  echo '----- Releasing app. -----'
+                  heroku container:release web --app $(herokuProject)
+                pwsh: true
+
+- stage: Verify
+  displayName: Verify deployment
+  jobs:
+    - job: Smoke
+      steps:
+      - task: PowerShell@2
+        displayName: "Ping test"
+        inputs:
+          filePath: 'smoke.ps1'
+          arguments: '-uri https://$(herokuProject).herokuapp.com/api/ping -code 200'
+          pwsh: true

--- a/pipelines/cd/feedback-survey-service-delivery.yml
+++ b/pipelines/cd/feedback-survey-service-delivery.yml
@@ -47,7 +47,7 @@ stages:
   variables:
     HEROKU_API_KEY: 8418d6b4-7423-404b-81cf-23abcd968591
   jobs:
-  - deployment: GraphicalEditor   
+  - deployment: FeedbackAndSurveyService   
     environment: 'Test'
     strategy:
       runOnce:
@@ -77,6 +77,6 @@ stages:
       - task: PowerShell@2
         displayName: "Ping test"
         inputs:
-          filePath: 'smoke.ps1'
+          filePath: 'pipelines/cd/smoke.ps1'
           arguments: '-uri https://$(herokuProject).herokuapp.com/api/ping -code 200'
           pwsh: true

--- a/pipelines/cd/feedback-survey-service-delivery.yml
+++ b/pipelines/cd/feedback-survey-service-delivery.yml
@@ -1,0 +1,82 @@
+trigger:
+  branches:
+    include:
+    - develop
+  paths:
+    include:
+    - 'HealthcareSystem/FeedbackAndSurveyService/*'
+    - 'HealthcareSystem/Backend/*'
+pr: none
+
+pool:
+  vmImage: 'ubuntu-18.04'
+
+variables:
+  dockerRegistry: 'pufkedockerhub'
+  project: 'HealthcareSystem/FeedbackAndSurveyService/FeedbackAndSurveyService.csproj'
+  dockerfile: 'HealthcareSystem/FeedbackAndSurveyService/Dockerfile'
+  dockerImage: 'pufke/feedbackandsurveyservice'
+  herokuProject: 'vlaksi-feedback-and-survey'
+
+stages:
+- stage: CI
+  jobs:
+  - job: Docker
+    steps:
+    - task: Bash@3
+      displayName: 'Prepare context for Docker'
+      inputs:
+        targetType: 'inline'
+        script: |
+          docker --version
+          dotnet publish $(project) -c Release -o publish
+          cp $(dockerfile) publish/Dockerfile  
+    - task: Docker@2
+      displayName: 'Build and push Docker image'
+      inputs:
+        containerRegistry: '$(dockerRegistry)'
+        repository: '$(dockerImage)'
+        command: 'buildAndPush'
+        Dockerfile: 'publish/Dockerfile'
+        buildContext: 'publish'
+        tags: |
+          $(Build.BuildId)
+          latest
+
+- stage: CD
+  variables:
+    HEROKU_API_KEY: 8418d6b4-7423-404b-81cf-23abcd968591
+  jobs:
+  - deployment: GraphicalEditor   
+    environment: 'Test'
+    strategy:
+      runOnce:
+        deploy:                 
+          steps:
+            - task: PowerShell@2
+              displayName: "Heroku Deployment"
+              inputs:
+                targetType: 'inline'
+                script: |
+                  echo "----- Logging in to Heroku registry. -----"
+                  heroku container:login
+                  echo '----- Pulling image from DockerHub. -----'
+                  docker pull $(dockerImage)
+                  echo '----- Pushing to Heroku registry. -----'
+                  docker tag $(dockerImage) registry.heroku.com/$(herokuProject)/web
+                  docker push registry.heroku.com/$(herokuProject)/web
+                  echo '----- Releasing app. -----'
+                  heroku container:release web --app $(herokuProject)
+                pwsh: true
+
+- stage: Verify
+  displayName: Verify deployment
+  jobs:
+    - job: Smoke
+      steps:
+      - task: PowerShell@2
+        displayName: "Ping test"
+        inputs:
+          filePath: 'smoke.ps1'
+          arguments: '-uri https://$(herokuProject).herokuapp.com/api/ping -code 200'
+          pwsh: true

--- a/pipelines/cd/notification-service-delivery.yml
+++ b/pipelines/cd/notification-service-delivery.yml
@@ -1,0 +1,81 @@
+trigger:
+  branches:
+    include:
+    - develop
+  paths:
+    include:
+    - 'HealthcareSystem/NotificationService/*'
+pr: none
+
+pool:
+  vmImage: 'ubuntu-18.04'
+
+variables:
+  dockerRegistry: 'pufkedockerhub'
+  project: 'HealthcareSystem/NotificationService/NotificationService.csproj'
+  dockerfile: 'HealthcareSystem/NotificationService/Dockerfile'
+  dockerImage: 'pufke/notificationservice'
+  herokuProject: 'vlaksi-notification-service'
+
+stages:
+- stage: CI
+  jobs:
+  - job: Docker
+    steps:
+    - task: Bash@3
+      displayName: 'Prepare context for Docker'
+      inputs:
+        targetType: 'inline'
+        script: |
+          docker --version
+          dotnet publish $(project) -c Release -o publish
+          cp $(dockerfile) publish/Dockerfile  
+    - task: Docker@2
+      displayName: 'Build and push Docker image'
+      inputs:
+        containerRegistry: '$(dockerRegistry)'
+        repository: '$(dockerImage)'
+        command: 'buildAndPush'
+        Dockerfile: 'publish/Dockerfile'
+        buildContext: 'publish'
+        tags: |
+          $(Build.BuildId)
+          latest
+
+- stage: CD
+  variables:
+    HEROKU_API_KEY: 8418d6b4-7423-404b-81cf-23abcd968591
+  jobs:
+  - deployment: GraphicalEditor   
+    environment: 'Test'
+    strategy:
+      runOnce:
+        deploy:                 
+          steps:
+            - task: PowerShell@2
+              displayName: "Heroku Deployment"
+              inputs:
+                targetType: 'inline'
+                script: |
+                  echo "----- Logging in to Heroku registry. -----"
+                  heroku container:login
+                  echo '----- Pulling image from DockerHub. -----'
+                  docker pull $(dockerImage)
+                  echo '----- Pushing to Heroku registry. -----'
+                  docker tag $(dockerImage) registry.heroku.com/$(herokuProject)/web
+                  docker push registry.heroku.com/$(herokuProject)/web
+                  echo '----- Releasing app. -----'
+                  heroku container:release web --app $(herokuProject)
+                pwsh: true
+
+- stage: Verify
+  displayName: Verify deployment
+  jobs:
+    - job: Smoke
+      steps:
+      - task: PowerShell@2
+        displayName: "Ping test"
+        inputs:
+          filePath: 'smoke.ps1'
+          arguments: '-uri https://$(herokuProject).herokuapp.com/api/ping -code 200'
+          pwsh: true

--- a/pipelines/cd/notification-service-delivery.yml
+++ b/pipelines/cd/notification-service-delivery.yml
@@ -46,7 +46,7 @@ stages:
   variables:
     HEROKU_API_KEY: 8418d6b4-7423-404b-81cf-23abcd968591
   jobs:
-  - deployment: GraphicalEditor   
+  - deployment: NotificationService  
     environment: 'Test'
     strategy:
       runOnce:
@@ -76,6 +76,6 @@ stages:
       - task: PowerShell@2
         displayName: "Ping test"
         inputs:
-          filePath: 'smoke.ps1'
+          filePath: 'pipelines/cd/smoke.ps1'
           arguments: '-uri https://$(herokuProject).herokuapp.com/api/ping -code 200'
           pwsh: true

--- a/pipelines/cd/patient-service-delivery.yml
+++ b/pipelines/cd/patient-service-delivery.yml
@@ -1,0 +1,82 @@
+trigger:
+  branches:
+    include:
+    - develop
+  paths:
+    include:
+    - 'HealthcareSystem/PatientService/*'
+    - 'HealthcareSystem/Backend/*'
+pr: none
+
+pool:
+  vmImage: 'ubuntu-18.04'
+
+variables:
+  dockerRegistry: 'pufkedockerhub'
+  project: 'HealthcareSystem/PatientService/PatientService.csproj'
+  dockerfile: 'HealthcareSystem/PatientService/Dockerfile'
+  dockerImage: 'pufke/patientservice'
+  herokuProject: 'vlaksi-patient-service'
+
+stages:
+- stage: CI
+  jobs:
+  - job: Docker
+    steps:
+    - task: Bash@3
+      displayName: 'Prepare context for Docker'
+      inputs:
+        targetType: 'inline'
+        script: |
+          docker --version
+          dotnet publish $(project) -c Release -o publish
+          cp $(dockerfile) publish/Dockerfile  
+    - task: Docker@2
+      displayName: 'Build and push Docker image'
+      inputs:
+        containerRegistry: '$(dockerRegistry)'
+        repository: '$(dockerImage)'
+        command: 'buildAndPush'
+        Dockerfile: 'publish/Dockerfile'
+        buildContext: 'publish'
+        tags: |
+          $(Build.BuildId)
+          latest
+
+- stage: CD
+  variables:
+    HEROKU_API_KEY: 8418d6b4-7423-404b-81cf-23abcd968591
+  jobs:
+  - deployment: GraphicalEditor   
+    environment: 'Test'
+    strategy:
+      runOnce:
+        deploy:                 
+          steps:
+            - task: PowerShell@2
+              displayName: "Heroku Deployment"
+              inputs:
+                targetType: 'inline'
+                script: |
+                  echo "----- Logging in to Heroku registry. -----"
+                  heroku container:login
+                  echo '----- Pulling image from DockerHub. -----'
+                  docker pull $(dockerImage)
+                  echo '----- Pushing to Heroku registry. -----'
+                  docker tag $(dockerImage) registry.heroku.com/$(herokuProject)/web
+                  docker push registry.heroku.com/$(herokuProject)/web
+                  echo '----- Releasing app. -----'
+                  heroku container:release web --app $(herokuProject)
+                pwsh: true
+
+- stage: Verify
+  displayName: Verify deployment
+  jobs:
+    - job: Smoke
+      steps:
+      - task: PowerShell@2
+        displayName: "Ping test"
+        inputs:
+          filePath: 'smoke.ps1'
+          arguments: '-uri https://$(herokuProject).herokuapp.com/api/ping -code 200'
+          pwsh: true

--- a/pipelines/cd/patient-service-delivery.yml
+++ b/pipelines/cd/patient-service-delivery.yml
@@ -47,7 +47,7 @@ stages:
   variables:
     HEROKU_API_KEY: 8418d6b4-7423-404b-81cf-23abcd968591
   jobs:
-  - deployment: GraphicalEditor   
+  - deployment: PatientService   
     environment: 'Test'
     strategy:
       runOnce:
@@ -77,6 +77,6 @@ stages:
       - task: PowerShell@2
         displayName: "Ping test"
         inputs:
-          filePath: 'smoke.ps1'
+          filePath: 'pipelines/cd/smoke.ps1'
           arguments: '-uri https://$(herokuProject).herokuapp.com/api/ping -code 200'
           pwsh: true

--- a/pipelines/cd/patientwebapp-delivery.yml
+++ b/pipelines/cd/patientwebapp-delivery.yml
@@ -1,0 +1,82 @@
+trigger:
+  branches:
+    include:
+    - develop
+  paths:
+    include:
+    - 'HealthcareSystem/PatientWebApp/*'
+    - 'HealthcareSystem/Backend/*'
+pr: none
+
+pool:
+  vmImage: 'ubuntu-18.04'
+
+variables:
+  dockerRegistry: 'pufkedockerhub'
+  project: 'HealthcareSystem/PatientWebApp/PatientWebApp.csproj'
+  dockerfile: 'HealthcareSystem/PatientWebApp/Dockerfile'
+  dockerImage: 'pufke/patientwebapp'
+  herokuProject: 'vlaksi-patientwebapp'
+
+stages:
+- stage: CI
+  jobs:
+  - job: Docker
+    steps:
+    - task: Bash@3
+      displayName: 'Prepare context for Docker'
+      inputs:
+        targetType: 'inline'
+        script: |
+          docker --version
+          dotnet publish $(project) -c Release -o publish
+          cp $(dockerfile) publish/Dockerfile  
+    - task: Docker@2
+      displayName: 'Build and push Docker image'
+      inputs:
+        containerRegistry: '$(dockerRegistry)'
+        repository: '$(dockerImage)'
+        command: 'buildAndPush'
+        Dockerfile: 'publish/Dockerfile'
+        buildContext: 'publish'
+        tags: |
+          $(Build.BuildId)
+          latest
+
+- stage: CD
+  variables:
+    HEROKU_API_KEY: 8418d6b4-7423-404b-81cf-23abcd968591
+  jobs:
+  - deployment: PatientWebApp   
+    environment: 'Test'
+    strategy:
+      runOnce:
+        deploy:                 
+          steps:
+            - task: PowerShell@2
+              displayName: "Heroku Deployment"
+              inputs:
+                targetType: 'inline'
+                script: |
+                  echo "----- Logging in to Heroku registry. -----"
+                  heroku container:login
+                  echo '----- Pulling image from DockerHub. -----'
+                  docker pull $(dockerImage)
+                  echo '----- Pushing to Heroku registry. -----'
+                  docker tag $(dockerImage) registry.heroku.com/$(herokuProject)/web
+                  docker push registry.heroku.com/$(herokuProject)/web
+                  echo '----- Releasing app. -----'
+                  heroku container:release web --app $(herokuProject)
+                pwsh: true
+
+- stage: Verify
+  displayName: Verify deployment
+  jobs:
+    - job: Smoke
+      steps:
+      - task: PowerShell@2
+        displayName: "Ping test"
+        inputs:
+          filePath: 'pipelines/cd/smoke.ps1'
+          arguments: '-uri https://$(herokuProject).herokuapp.com/api/ping -code 200'
+          pwsh: true

--- a/pipelines/cd/smoke.ps1
+++ b/pipelines/cd/smoke.ps1
@@ -1,0 +1,23 @@
+Param(
+    [Parameter(Mandatory=$true)]
+    $uri,
+    [Parameter(Mandatory=$true)]
+    $code
+)
+
+For ($i=0; $i -lt 10; $i++) {
+    Write-Output "---------------------------------------"
+    Write-Output ("Attepmt #" + ($i + 1))
+    Write-Output "---------------------------------------"
+    $response = Invoke-WebRequest -Uri $uri -SkipHttpErrorCheck
+    $response
+    Write-Output ""
+    if ($response.StatusCode -eq $code){
+        Write-Output "Smoke test successful."
+        Exit
+    }
+    Start-Sleep -s 10
+}
+
+Write-Output "Smoke test failed."
+Exit 1

--- a/pipelines/cd/user-service-delivery.yml
+++ b/pipelines/cd/user-service-delivery.yml
@@ -1,0 +1,82 @@
+trigger:
+  branches:
+    include:
+    - develop
+  paths:
+    include:
+    - 'HealthcareSystem/UserService/*'
+    - 'HealthcareSystem/Backend/*'
+pr: none
+
+pool:
+  vmImage: 'ubuntu-18.04'
+
+variables:
+  dockerRegistry: 'pufkedockerhub'
+  project: 'HealthcareSystem/UserService/UserService.csproj'
+  dockerfile: 'HealthcareSystem/UserService/Dockerfile'
+  dockerImage: 'pufke/userservice'
+  herokuProject: 'vlaksi-user-service'
+
+stages:
+- stage: CI
+  jobs:
+  - job: Docker
+    steps:
+    - task: Bash@3
+      displayName: 'Prepare context for Docker'
+      inputs:
+        targetType: 'inline'
+        script: |
+          docker --version
+          dotnet publish $(project) -c Release -o publish
+          cp $(dockerfile) publish/Dockerfile  
+    - task: Docker@2
+      displayName: 'Build and push Docker image'
+      inputs:
+        containerRegistry: '$(dockerRegistry)'
+        repository: '$(dockerImage)'
+        command: 'buildAndPush'
+        Dockerfile: 'publish/Dockerfile'
+        buildContext: 'publish'
+        tags: |
+          $(Build.BuildId)
+          latest
+
+- stage: CD
+  variables:
+    HEROKU_API_KEY: 8418d6b4-7423-404b-81cf-23abcd968591
+  jobs:
+  - deployment: GraphicalEditor   
+    environment: 'Test'
+    strategy:
+      runOnce:
+        deploy:                 
+          steps:
+            - task: PowerShell@2
+              displayName: "Heroku Deployment"
+              inputs:
+                targetType: 'inline'
+                script: |
+                  echo "----- Logging in to Heroku registry. -----"
+                  heroku container:login
+                  echo '----- Pulling image from DockerHub. -----'
+                  docker pull $(dockerImage)
+                  echo '----- Pushing to Heroku registry. -----'
+                  docker tag $(dockerImage) registry.heroku.com/$(herokuProject)/web
+                  docker push registry.heroku.com/$(herokuProject)/web
+                  echo '----- Releasing app. -----'
+                  heroku container:release web --app $(herokuProject)
+                pwsh: true
+
+- stage: Verify
+  displayName: Verify deployment
+  jobs:
+    - job: Smoke
+      steps:
+      - task: PowerShell@2
+        displayName: "Ping test"
+        inputs:
+          filePath: 'smoke.ps1'
+          arguments: '-uri https://$(herokuProject).herokuapp.com/api/ping -code 200'
+          pwsh: true

--- a/pipelines/cd/user-service-delivery.yml
+++ b/pipelines/cd/user-service-delivery.yml
@@ -47,7 +47,7 @@ stages:
   variables:
     HEROKU_API_KEY: 8418d6b4-7423-404b-81cf-23abcd968591
   jobs:
-  - deployment: GraphicalEditor   
+  - deployment: UserService
     environment: 'Test'
     strategy:
       runOnce:
@@ -77,6 +77,6 @@ stages:
       - task: PowerShell@2
         displayName: "Ping test"
         inputs:
-          filePath: 'smoke.ps1'
+          filePath: 'pipelines/cd/smoke.ps1'
           arguments: '-uri https://$(herokuProject).herokuapp.com/api/ping -code 200'
           pwsh: true


### PR DESCRIPTION
- Services added to test env on Heroku.
- Existing delivery pipelines reconfigured and pipelines added for new components. The new delivery pipelines will only redeploy components that have been changed. Database reset and E2E tests will run on every commit on develop.
- Simple ping endpoints added to all servers for smoke testing.
- Data seeding changed to work through SQL scripts generated from a DbContext. This decision was made because in the previous approach one of the components had to be responsible for data seeding, which meant that it had to be redeployed whenever we wanted to reset the database, and also that data seeding was attempted every time Heroku restarted the container.
- Data seeding was also changed so that EF migrations and script generation can be invoked through Backend instead of through the ASP.NET apps, with the goal to make script generation faster. This was achieved by adding the classes PostgreSeededDbContext and MySqlSeededDbContext which provide empty constructors so that EF can instantiate them. This implementation is very far from ideal, however, as far as I'm aware we have no other option since EF Core 3.1 has a bug that makes context factories ignore arguments that are passed in (which means that we wouldn't be able to generate both scripts for Postgre and for MySql).
- The E2E pipeline is set up but isn't quite finished yet (since we don't have E2E tests right now). It will be properly finished on another branch when E2E tests are added.