### PR TITLE
Chore[d76, d77]: configure E2E tests and fix E2E pipeline

### DIFF
--- a/HealthcareSystem/SeleniumTests/AddFeedbackTests.cs
+++ b/HealthcareSystem/SeleniumTests/AddFeedbackTests.cs
@@ -22,9 +22,12 @@ namespace PatientWebAppE2ETests
 
             driver = new FirefoxDriver(options);
 
-            loginPage = new Pages.LoginPage(driver);
+            loginPage = new Pages.LoginPage(driver,
+                                            Configuration.LoginPageURI,
+                                            Configuration.AdminHomePageURI,
+                                            Configuration.PatientHomePageURI);
             loginPage.Navigate();
-            Assert.Equal(driver.Url, Pages.LoginPage.URI);
+            Assert.Equal(driver.Url, Configuration.LoginPageURI);
         }
         public void Dispose()
         {
@@ -33,7 +36,7 @@ namespace PatientWebAppE2ETests
         }
 
         [Fact]
-        public void TestSuccessfulSubmit() 
+        public void TestSuccessfulSubmit()
         {
             try
             {
@@ -42,9 +45,9 @@ namespace PatientWebAppE2ETests
                 loginPage.SubmitForm();
                 loginPage.WaitForLoginPatient();
 
-                addFeedbackPage = new Pages.AddFeedbackPage(driver);
+                addFeedbackPage = new Pages.AddFeedbackPage(driver, Configuration.AddFeedbackPageURI);
                 addFeedbackPage.Navigate();
-                Assert.Equal(driver.Url, Pages.AddFeedbackPage.URI);
+                Assert.Equal(driver.Url, Configuration.AddFeedbackPageURI);
 
                 addFeedbackPage.InsertComment("Sve je super!");
                 addFeedbackPage.InsertIsAnonymous("yes");
@@ -71,9 +74,9 @@ namespace PatientWebAppE2ETests
                 loginPage.SubmitForm();
                 loginPage.WaitForLoginPatient();
 
-                addFeedbackPage = new Pages.AddFeedbackPage(driver);
+                addFeedbackPage = new Pages.AddFeedbackPage(driver, Configuration.AddFeedbackPageURI);
                 addFeedbackPage.Navigate();
-                Assert.Equal(driver.Url, Pages.AddFeedbackPage.URI);
+                Assert.Equal(driver.Url, Configuration.AddFeedbackPageURI);
 
                 addFeedbackPage.InsertIsAnonymous("yes");
                 addFeedbackPage.InsertIsAllowed("yes");
@@ -87,7 +90,7 @@ namespace PatientWebAppE2ETests
             {
                 Dispose();
             }
-            
+
         }
 
     }

--- a/HealthcareSystem/SeleniumTests/BlockMaliciousPatientTests.cs
+++ b/HealthcareSystem/SeleniumTests/BlockMaliciousPatientTests.cs
@@ -8,7 +8,7 @@ namespace PatientWebAppE2ETests
     public class BlockMaliciousPatientTests : IDisposable
     {
         private readonly IWebDriver driver;
-        private Pages.BlockMaliciousPatient blockPatientPage;
+        private Pages.BlockMaliciousPatientPage blockPatientPage;
         private Pages.LoginPage loginPage;
 
         public BlockMaliciousPatientTests()
@@ -22,10 +22,14 @@ namespace PatientWebAppE2ETests
 
             driver = new FirefoxDriver(options);
 
-            loginPage = new Pages.LoginPage(driver);
+            loginPage = new Pages.LoginPage(driver,
+                                            Configuration.LoginPageURI,
+                                            Configuration.AdminHomePageURI,
+                                            Configuration.PatientHomePageURI);
             loginPage.Navigate();
-            Assert.Equal(driver.Url, Pages.LoginPage.URI);
+            Assert.Equal(driver.Url, Configuration.LoginPageURI);
         }
+
         public void Dispose()
         {
             driver.Quit();
@@ -42,11 +46,11 @@ namespace PatientWebAppE2ETests
                 loginPage.SubmitForm();
                 loginPage.WaitForLoginAdmin();
 
-                blockPatientPage = new Pages.BlockMaliciousPatient(driver);
+                blockPatientPage = new Pages.BlockMaliciousPatientPage(driver, Configuration.BlockMaliciousPatientPageURI);
                 blockPatientPage.Navigate();
-                Assert.Equal(driver.Url, Pages.BlockMaliciousPatient.URI);
+                Assert.Equal(driver.Url, Configuration.BlockMaliciousPatientPageURI);
 
-                Assert.Contains(Pages.BlockMaliciousPatient.ValidCommentMessage, blockPatientPage.BlockPatient());
+                Assert.Contains(Pages.BlockMaliciousPatientPage.ValidCommentMessage, blockPatientPage.BlockPatient());
             }
             finally
             {

--- a/HealthcareSystem/SeleniumTests/CancelExaminationTests .cs
+++ b/HealthcareSystem/SeleniumTests/CancelExaminationTests .cs
@@ -21,9 +21,12 @@ namespace PatientWebAppE2ETests
 
             driver = new FirefoxDriver(options);
 
-            loginPage = new Pages.LoginPage(driver);
+            loginPage = new Pages.LoginPage(driver,
+                                            Configuration.LoginPageURI,
+                                            Configuration.AdminHomePageURI,
+                                            Configuration.PatientHomePageURI);
             loginPage.Navigate();
-            Assert.Equal(driver.Url, Pages.LoginPage.URI);
+            Assert.Equal(driver.Url, Configuration.LoginPageURI);
         }
 
         public void Dispose()
@@ -42,9 +45,9 @@ namespace PatientWebAppE2ETests
                 loginPage.SubmitForm();
                 loginPage.WaitForLoginPatient();
 
-                patientExaminationsPage = new Pages.PatientExaminationsPage(driver);
+                patientExaminationsPage = new Pages.PatientExaminationsPage(driver, Configuration.ExaminationPageURI);
                 patientExaminationsPage.Navigate();
-                Assert.Equal(driver.Url, Pages.PatientExaminationsPage.URI);
+                Assert.Equal(driver.Url, Configuration.ExaminationPageURI);
 
                 Assert.Contains(Pages.PatientExaminationsPage.ValidCommentMessage, patientExaminationsPage.CancelExaminationClick());
             }

--- a/HealthcareSystem/SeleniumTests/Configuration.cs
+++ b/HealthcareSystem/SeleniumTests/Configuration.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace PatientWebAppE2ETests
+{
+    static class Configuration
+    {
+        public static string Host
+        {
+            get => Environment.GetEnvironmentVariable("PWA_HOST") ?? "http://localhost:65117";
+        }
+
+        public static string AddFeedbackPageURI
+        {
+            get => Host + "/html/add_feedback.html";
+        }
+
+        public static string BlockMaliciousPatientPageURI
+        {
+            get => Host + "/html/malicious_patients.html";
+        }
+
+        public static string LoginPageURI
+        {
+            get => Host + "/html/login.html";
+        }
+
+        public static string PatientHomePageURI
+        {
+            get => Host + "/html/patients_home_page.html";
+        }
+
+        public static string AdminHomePageURI
+        {
+            get => Host + "/html/admins_home_page.html";
+        }
+
+        public static string ExaminationPageURI
+        {
+            get => Host + "/html/patient_examinations.html";
+        }
+
+        public static string PublishFeedbackPageURI
+        {
+            get => Host + "/html/admins_home_page.html";
+        }
+    }
+}

--- a/HealthcareSystem/SeleniumTests/Pages/AddFeedbackPage.cs
+++ b/HealthcareSystem/SeleniumTests/Pages/AddFeedbackPage.cs
@@ -7,7 +7,7 @@ namespace PatientWebAppE2ETests.Pages
     public class AddFeedbackPage
     {
         private readonly IWebDriver driver;
-        public const string URI = "http://localhost:65117/html/add_feedback.html";
+        private readonly string URI;
         private IWebElement CommentElement => driver.FindElement(By.Id("text_area_id"));
         private IWebElement IsAnonymousElement => driver.FindElement(By.XPath("//input[@id = 'no_anonymous']"));
         private IWebElement IsAllowedElement => driver.FindElement(By.XPath(".//div[contains(.,'I don't want my feedback to be published')]/input"));
@@ -17,9 +17,10 @@ namespace PatientWebAppE2ETests.Pages
         public const string ValidCommentMessage = "You have successfuly left a feedback";
         public const string InvalidCommentMessage = "Feedback cannot be empty";
 
-        public AddFeedbackPage(IWebDriver driver)
+        public AddFeedbackPage(IWebDriver driver, string uri)
         {
             this.driver = driver;
+            URI = uri;
         }
 
         public void InsertComment(string comment)

--- a/HealthcareSystem/SeleniumTests/Pages/BlockMaliciousPatientPage.cs
+++ b/HealthcareSystem/SeleniumTests/Pages/BlockMaliciousPatientPage.cs
@@ -4,16 +4,17 @@ using OpenQA.Selenium.Support.UI;
 
 namespace PatientWebAppE2ETests.Pages
 {
-    public class BlockMaliciousPatient
+    public class BlockMaliciousPatientPage
     {
         private readonly IWebDriver driver;
-        public const string URI = "http://localhost:65117/html/malicious_patients.html";
+        private readonly string URI;
 
         public const string ValidCommentMessage = "Patient was successfully blocked.";
 
-        public BlockMaliciousPatient(IWebDriver driver)
+        public BlockMaliciousPatientPage(IWebDriver driver, string uri)
         {
             this.driver = driver;
+            URI = uri;
         }
 
         public string BlockPatient()

--- a/HealthcareSystem/SeleniumTests/Pages/LoginPage.cs
+++ b/HealthcareSystem/SeleniumTests/Pages/LoginPage.cs
@@ -7,15 +7,21 @@ namespace PatientWebAppE2ETests.Pages
     public class LoginPage
     {
         private readonly IWebDriver driver;
-        public const string URI = "http://localhost:65117/html/login.html";
+        private readonly string URI;
+        private readonly string adminHomePageURI;
+        private readonly string patientHomePageURI;
         private IWebElement EmailElement => driver.FindElement(By.Id("email"));
         private IWebElement PasswordElement => driver.FindElement(By.Id("password"));
         private IWebElement SubmitButtonElement => driver.FindElement(By.Id("login"));
 
-        public LoginPage(IWebDriver driver)
+        public LoginPage(IWebDriver driver, string uri, string adminUri, string patientUri)
         {
             this.driver = driver;
+            URI = uri;
+            adminHomePageURI = adminUri;
+            patientHomePageURI = patientUri;
         }
+
         public bool EmailElementDisplayed()
         {
             return EmailElement.Displayed;
@@ -49,13 +55,13 @@ namespace PatientWebAppE2ETests.Pages
         public void WaitForLoginPatient()
         {
             var wait = new WebDriverWait(driver, new TimeSpan(0, 0, 20));
-            wait.Until(SeleniumExtras.WaitHelpers.ExpectedConditions.UrlToBe("http://localhost:65117/html/patients_home_page.html"));
+            wait.Until(SeleniumExtras.WaitHelpers.ExpectedConditions.UrlToBe(patientHomePageURI));
         }
 
         public void WaitForLoginAdmin()
         {
             var wait = new WebDriverWait(driver, new TimeSpan(0, 0, 20));
-            wait.Until(SeleniumExtras.WaitHelpers.ExpectedConditions.UrlToBe("http://localhost:65117/html/admins_home_page.html"));
+            wait.Until(SeleniumExtras.WaitHelpers.ExpectedConditions.UrlToBe(adminHomePageURI));
         }
 
         public void Navigate() => driver.Navigate().GoToUrl(URI);

--- a/HealthcareSystem/SeleniumTests/Pages/PatientExaminationsPage.cs
+++ b/HealthcareSystem/SeleniumTests/Pages/PatientExaminationsPage.cs
@@ -7,8 +7,7 @@ namespace PatientWebAppE2ETests.Pages
     public class PatientExaminationsPage
     {
         private readonly IWebDriver driver;
-
-        public const string URI = "http://localhost:65117/html/patient_examinations.html";
+        private readonly string URI;
 
         private IWebElement ButtonElement => driver.FindElement(By.Name("cancelButton"));
 
@@ -17,9 +16,10 @@ namespace PatientWebAppE2ETests.Pages
         public const string ValidCommentMessage = "Examination successfully cancelled.";
 
 
-        public PatientExaminationsPage(IWebDriver driver)
+        public PatientExaminationsPage(IWebDriver driver, string uri)
         {
             this.driver = driver;
+            URI = uri;
         }
 
         public bool ButtonElementDisplayed()

--- a/HealthcareSystem/SeleniumTests/Pages/PublishFeedbackPage.cs
+++ b/HealthcareSystem/SeleniumTests/Pages/PublishFeedbackPage.cs
@@ -4,15 +4,16 @@ using System;
 
 namespace PatientWebAppE2ETests.Pages
 {
-    public class PublishFeedback
+    public class PublishFeedbackPage
     {
         private readonly IWebDriver driver;
-        public const string URI = "http://localhost:65117/html/admins_home_page.html";
+        private readonly string URI;
 
         public const string ValidCommentMessage = "Feedback successfully published.";
-        public PublishFeedback(IWebDriver driver)
+        public PublishFeedbackPage(IWebDriver driver, string uri)
         {
             this.driver = driver;
+            URI = uri;
         }
 
         public string Publish()

--- a/HealthcareSystem/SeleniumTests/PublishFeedbackTests.cs
+++ b/HealthcareSystem/SeleniumTests/PublishFeedbackTests.cs
@@ -8,7 +8,7 @@ namespace PatientWebAppE2ETests
     public class PublishFeedbackTests : IDisposable
     {
         private readonly IWebDriver driver;
-        private Pages.PublishFeedback publishFeedbackPage;
+        private Pages.PublishFeedbackPage publishFeedbackPage;
         private Pages.LoginPage loginPage;
 
         public PublishFeedbackTests()
@@ -22,9 +22,12 @@ namespace PatientWebAppE2ETests
 
             driver = new FirefoxDriver(options);
 
-            loginPage = new Pages.LoginPage(driver);
+            loginPage = new Pages.LoginPage(driver,
+                                            Configuration.LoginPageURI,
+                                            Configuration.AdminHomePageURI,
+                                            Configuration.PatientHomePageURI);
             loginPage.Navigate();
-            Assert.Equal(driver.Url, Pages.LoginPage.URI);
+            Assert.Equal(driver.Url, Configuration.LoginPageURI);
         }
         public void Dispose()
         {
@@ -42,11 +45,11 @@ namespace PatientWebAppE2ETests
                 loginPage.SubmitForm();
                 loginPage.WaitForLoginAdmin();
 
-                publishFeedbackPage = new Pages.PublishFeedback(driver);
+                publishFeedbackPage = new Pages.PublishFeedbackPage(driver, Configuration.PublishFeedbackPageURI);
                 publishFeedbackPage.Navigate();
-                Assert.Equal(driver.Url, Pages.PublishFeedback.URI);
+                Assert.Equal(driver.Url, Configuration.PublishFeedbackPageURI);
 
-                Assert.Contains(Pages.PublishFeedback.ValidCommentMessage, publishFeedbackPage.Publish());
+                Assert.Contains(Pages.PublishFeedbackPage.ValidCommentMessage, publishFeedbackPage.Publish());
             }
             finally
             {

--- a/pipelines/cd/e2e-on-heroku.yml
+++ b/pipelines/cd/e2e-on-heroku.yml
@@ -128,10 +128,50 @@ stages:
   jobs:
   - job: Test
     steps:
+    - task: UseDotNet@2
+      displayName: 'Use .NET Core SDK 3.1.x'
+      inputs:
+        packageType: 'sdk'
+        version: '3.1.x'
     - task: PowerShell@2
       displayName: 'Run tests'
       inputs:
         targetType: 'inline'
         script: |
           #
-          #dotnet test $(e2etests)
+          $Env:PWA_HOST = "https://psw-patientwebapp.herokuapp.com"
+          dotnet test $(e2etests)
+          
+
+- stage: UndoDbChanges
+  displayName: Undo database changes from tests
+  variables:
+    HEROKU_API_KEY: a191be3d-3484-49dc-a542-8f47c02c1ad9
+  jobs:  
+  - job: ResetDb
+    displayName: Reset database
+    steps:
+      - task: UseDotNet@2
+        inputs:
+          packageType: 'sdk'
+          version: '3.1.x'
+      - task: PowerShell@2
+        displayName: "Generate SQL script"
+        inputs:
+          targetType: 'inline'
+          script: |
+            echo "----- Installing EF Core. -----"
+            dotnet tool install --global dotnet-ef --version 3.1.9
+            echo "----- Generating script. -----"
+            dotnet-ef dbcontext script -c "PostgreSeededDbContext" -p "./HealthcareSystem/Backend/Backend.csproj" -o init.sql
+          pwsh: true
+      - task: PowerShell@2
+        displayName: "Initialize Heroku Postgres"
+        inputs:
+          targetType: 'inline'
+          script: |
+            echo "----- Reseting database. -----"
+            heroku pg:reset DATABASE_URL --app psw-patient-service --confirm psw-patient-service
+            echo "----- Initializing database. -----"
+            Get-Content init.sql | heroku pg:psql DATABASE_URL --app psw-patient-service
+          pwsh: true     

--- a/pipelines/cd/e2e-on-heroku.yml
+++ b/pipelines/cd/e2e-on-heroku.yml
@@ -9,13 +9,23 @@ pool:
   vmImage: 'ubuntu-18.04'
 
 stages:
+- stage: Wait
+  displayName: Wait for component redeployments
+  jobs:
+  - job: Wait
+    displayName: Wait for component redeployments
+    pool: Server
+    steps:
+    - task: Delay@1
+      inputs:
+        delayForMinutes: '5' 
+
 - stage: Prepare
   displayName: Prepare for tests
   variables:
     HEROKU_API_KEY: a191be3d-3484-49dc-a542-8f47c02c1ad9
   jobs:  
   - job: ResetDb
-    dependsOn: Wait
     displayName: Reset database
     steps:
       - task: UseDotNet@2
@@ -42,14 +52,6 @@ stages:
             echo "----- Initializing database. -----"
             Get-Content init.sql | heroku pg:psql DATABASE_URL --app psw-patient-service
           pwsh: true     
-
-  - job: Wait
-    displayName: Wait for component redeployments
-    pool: Server
-    steps:
-    - task: Delay@1
-      inputs:
-        delayForMinutes: '5' 
 
 - stage: Smoke
   displayName: Run smoke tests

--- a/pipelines/cd/e2e-on-heroku.yml
+++ b/pipelines/cd/e2e-on-heroku.yml
@@ -141,6 +141,8 @@ stages:
           
 
 - stage: UndoDbChanges
+  dependsOn: E2E
+  condition: succeededOrFailed()
   displayName: Undo database changes from tests
   variables:
     HEROKU_API_KEY: a191be3d-3484-49dc-a542-8f47c02c1ad9

--- a/pipelines/cd/e2e-on-heroku.yml
+++ b/pipelines/cd/e2e-on-heroku.yml
@@ -123,21 +123,13 @@ stages:
 
 - stage: E2E
   displayName: Run E2E tests
+  pool:
+    vmImage: 'windows-latest'
   variables:
     e2etests: 'HealthcareSystem/SeleniumTests/PatientWebAppE2ETests.csproj'
   jobs:
   - job: Test
     steps:
-    - task: UseDotNet@2
-      displayName: 'Use .NET Core SDK 3.1.x'
-      inputs:
-        packageType: 'sdk'
-        version: '3.1.x'
-    - task: DotNetCoreCLI@2
-      inputs:
-        command: 'restore'
-        projects: '$(e2etests)'
-        feedsToUse: 'select'
     - task: PowerShell@2
       displayName: 'Run tests'
       inputs:

--- a/pipelines/cd/e2e-on-heroku.yml
+++ b/pipelines/cd/e2e-on-heroku.yml
@@ -42,6 +42,8 @@ stages:
             echo "----- Generating script. -----"
             dotnet-ef dbcontext script -c "PostgreSeededDbContext" -p "./HealthcareSystem/Backend/Backend.csproj" -o init.sql
           pwsh: true
+      - publish: $(System.DefaultWorkingDirectory)/init.sql
+        artifact: script
       - task: PowerShell@2
         displayName: "Initialize Heroku Postgres"
         inputs:
@@ -152,20 +154,8 @@ stages:
   - job: ResetDb
     displayName: Reset database
     steps:
-      - task: UseDotNet@2
-        inputs:
-          packageType: 'sdk'
-          version: '3.1.x'
-      - task: PowerShell@2
-        displayName: "Generate SQL script"
-        inputs:
-          targetType: 'inline'
-          script: |
-            echo "----- Installing EF Core. -----"
-            dotnet tool install --global dotnet-ef --version 3.1.9
-            echo "----- Generating script. -----"
-            dotnet-ef dbcontext script -c "PostgreSeededDbContext" -p "./HealthcareSystem/Backend/Backend.csproj" -o init.sql
-          pwsh: true
+      - download: current
+        artifact: script
       - task: PowerShell@2
         displayName: "Initialize Heroku Postgres"
         inputs:
@@ -174,5 +164,5 @@ stages:
             echo "----- Reseting database. -----"
             heroku pg:reset DATABASE_URL --app psw-patient-service --confirm psw-patient-service
             echo "----- Initializing database. -----"
-            Get-Content init.sql | heroku pg:psql DATABASE_URL --app psw-patient-service
+            Get-Content $(Pipeline.Workspace)/script/init.sql | heroku pg:psql DATABASE_URL --app psw-patient-service
           pwsh: true     

--- a/pipelines/cd/e2e-on-heroku.yml
+++ b/pipelines/cd/e2e-on-heroku.yml
@@ -133,6 +133,11 @@ stages:
       inputs:
         packageType: 'sdk'
         version: '3.1.x'
+    - task: DotNetCoreCLI@2
+      inputs:
+        command: 'restore'
+        projects: '$(e2etests)'
+        feedsToUse: 'select'
     - task: PowerShell@2
       displayName: 'Run tests'
       inputs:


### PR DESCRIPTION
- E2E tests were change to make the host path configurable, to enable test execution on the Heroku test env through the pipeline and local execution.
- The issue with executing E2E tests in the pipeline was fixed. E2E tests will now execute whenever a change is pushed to develop.
- Other smaller changed were made to the E2E pipeline, such as:
  - The Wait job which delays the E2E pipeline until any eventual deployments are finished was separated into it's own stage, so that it can be easily skipped when running the pipeline manually.
  - An additional database reset was added after test execution, to remove any changes made by the tests. The first reset uploads the generated SQL script as an artifact so that the second reset can use it as well.